### PR TITLE
Add failing test for menu item clicking

### DIFF
--- a/src/FlaUI.Core.UITests/Elements/MenuTests.cs
+++ b/src/FlaUI.Core.UITests/Elements/MenuTests.cs
@@ -53,5 +53,14 @@ namespace FlaUI.Core.UITests.Elements
             Assert.That(fancy, Is.Not.Null);
             Assert.That(fancy.Properties.Name.Value, Is.EqualTo("Fancy"));
         }
+
+        [Test]
+        public void TestMenuItemClick()
+        {
+            var window = App.GetMainWindow(Automation);
+            var menu = window.FindFirstChild(cf => cf.Menu()).AsMenu();
+            var exitMenuItem = menu.Items["File"].Items["Exit"];
+            exitMenuItem.Click();
+        }
     }
 }


### PR DESCRIPTION
It seems that `Click()` doesn't work on Menu Item and I did a quick test that demonstrates its failure.

Any idea on why this happens? I am writing the bounding rectangle after the menu is shown, and it shows the correct one.

In the meantime I saw in a previous bug https://github.com/Roemer/FlaUI/issues/82 that if we use `Invoke` it should work, and indeed it works. However, on *visible* menu items (e.g., File/Edit) click works. Maybe we should make `Click()` use Invoke for MenuItems? Or maybe print some indication that `Click()` might not always work?