### PR TITLE
fixed GDI handle leak in CaptureCursor

### DIFF
--- a/src/FlaUI.Core/Capturing/CaptureUtilities.cs
+++ b/src/FlaUI.Core/Capturing/CaptureUtilities.cs
@@ -12,6 +12,9 @@ namespace FlaUI.Core.Capturing
     /// </summary>
     public static class CaptureUtilities
     {
+        [DllImport("Gdi32")]
+        public static extern bool DeleteObject(IntPtr ho);
+
         /// <summary>
         /// Calculates a scale factor according to the bounds and capture settings.
         /// </summary>
@@ -170,8 +173,16 @@ namespace FlaUI.Core.Capturing
             }
 
             // Just return the icon converted to a bitmap
-            var icon = Icon.FromHandle(hicon);
-            return icon.ToBitmap();
+            Bitmap result;
+            using (Icon icon = Icon.FromHandle(hicon))
+            {
+                result = icon.ToBitmap();
+            }
+
+            User32.DestroyIcon(hicon);
+            DeleteObject(iconInfo.hbmMask);
+            DeleteObject(iconInfo.hbmColor);
+            return result;
         }
     }
 }


### PR DESCRIPTION
I discovered this GDI handle leak when I try to capture screenshot with a MouseOverlay repeatedly. Eventually the process will reach the 100,000 GDI handle limit and throw an exception `System.Runtime.InteropServices.COMException: System.Runtime.InteropServices.COMException: MILERR_WIN32ERROR (Exception from HRESULT: 0x88980003).`