### PR TITLE
Add .Net Core 3.1 as build target & Fix for Process.MainWindowHandle

### DIFF
--- a/src/FlaUI.Core/Application.cs
+++ b/src/FlaUI.Core/Application.cs
@@ -19,7 +19,7 @@ namespace FlaUI.Core
         /// <summary>
         /// The process of this application.
         /// </summary>
-        private readonly Process _process;
+        private Process _process;
 
         /// <summary>
         /// Flag to indicate if Dispose has already been called.
@@ -287,8 +287,10 @@ namespace FlaUI.Core
             var waitTime = waitTimeout ?? TimeSpan.FromMilliseconds(-1);
             return Retry.WhileTrue(() =>
             {
-                _process.Refresh();
-                return _process.MainWindowHandle == IntPtr.Zero;
+              int processId = _process.Id;
+              _process.Dispose(); 
+              _process = FindProcess(processId); 
+              return _process.MainWindowHandle == IntPtr.Zero;
             }, waitTime, TimeSpan.FromMilliseconds(50)).Result;
         }
 

--- a/src/FlaUI.Core/FlaUI.Core.csproj
+++ b/src/FlaUI.Core/FlaUI.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net35;net40;net45;netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netstandard2.0;netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -33,7 +33,7 @@
     <IntermediateOutputPath>obj\$(Configuration)\Signed</IntermediateOutputPath>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="System.Diagnostics.PerformanceCounter">
       <Version>4.7.0</Version>
     </PackageReference>
@@ -51,7 +51,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'netcoreapp3.0' And '$(TargetFramework)' != 'netcoreapp3.1'">
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationCore" />
     <Reference Include="WindowsBase" />

--- a/src/FlaUI.UIA2/FlaUI.UIA2.csproj
+++ b/src/FlaUI.UIA2/FlaUI.UIA2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net35;net40;net45;net471;net48;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net471;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF> <!-- Needed so System.Windows.Automation is added -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -37,7 +37,7 @@
     <ProjectReference Include="..\FlaUI.Core\FlaUI.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0' Or '$(TargetFramework)' != 'netcoreapp3.1'">
     <Reference Include="UIAutomationClient" />
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />

--- a/src/FlaUI.UIA3/FlaUI.UIA3.csproj
+++ b/src/FlaUI.UIA3/FlaUI.UIA3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net35;net40;net45;netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netstandard2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -36,7 +36,7 @@
     <ProjectReference Include="..\FlaUI.Core\FlaUI.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'netcoreapp3.0' And '$(TargetFramework)' != 'netcoreapp3.1'">
     <Reference Include="Accessibility" />
     <Reference Include="WindowsBase" />
   </ItemGroup>


### PR DESCRIPTION
Hi! Great framework, I wanted to use this in combination with another .NET Core 3.1 library, hence the pull request!

Added .NET Core 3.1 as a target framework, did it the same way as it was done with .NET Core 3.0.

Added a fix for Application.cs where the process had to be created again to get a valid MainWindowHandle. The MainWindowHandle has a bug where it is evaluated once, and then it has that pointer forever. If it is evaluated early it will get a IntPtr.Zero resulting in us never getting a valid value. I've seen a lot of people write about this and it should be fixed when we get a new nuget package for System.Diagnostics.Process.
The issue with MainWindowHandle, ProcessManager.GetMainWindowHandle(_processId) can return IntPtr.Zero.
```csharp
public IntPtr MainWindowHandle
{
   get
   {
      if (!_haveMainWindow)
      {
         EnsureState(State.IsLocal | State.HaveId);
         _mainWindowHandle = ProcessManager.GetMainWindowHandle(_processId);

         _haveMainWindow = _mainWindowHandle != IntPtr.Zero;
      }
      return _mainWindowHandle;
   }
}