### PR TITLE
Change property from private set to protected set

### DIFF
--- a/src/FlaUI.TestUtilities/FlaUITestBase.cs
+++ b/src/FlaUI.TestUtilities/FlaUITestBase.cs
@@ -35,7 +35,7 @@ namespace FlaUI.TestUtilities
         /// <summary>
         /// Instance of the current running application.
         /// </summary>
-        protected Application Application { get; private set; }
+        protected Application Application { get; set; }
 
         /// <summary>
         /// Specifies the starting mode of the application to test.


### PR DESCRIPTION
Let inheritors set Application property so that it can be set when using ApplicationStartMode.None