### PR TITLE
Fix mistype in `RightDoubleClick()` mouse method

### DIFF
--- a/src/FlaUI.Core/Input/Mouse.cs
+++ b/src/FlaUI.Core/Input/Mouse.cs
@@ -468,7 +468,7 @@ namespace FlaUI.Core.Input
 
         public static void RightDoubleClick(Point point)
         {
-            DoubleClick(point, MouseButton.Left);
+            DoubleClick(point, MouseButton.Right);
         }
 
         #endregion Convenience methods


### PR DESCRIPTION
**Problem:** `RightDoubleClick()` method in `Mouse` class contains a mistype, so it is actually performs `LeftDoubleClick()`.

**Proposed fix:** Change `MouseButton` to `Right` to fix copy-paste issue.

**Description:**
I noticed a copy-paste issue in `Mouse` class while investigating the code online. Taking into account that `RightDoubleClick()` implementation seems to be wrong, I created this PR to fix this small issue.