### PR TITLE
Throw exception instead of hiding the error

### DIFF
--- a/src/FlaUI.Core/Input/Keyboard.cs
+++ b/src/FlaUI.Core/Input/Keyboard.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
-using FlaUI.Core.Logging;
 using FlaUI.Core.WindowsAPI;
 
 namespace FlaUI.Core.Input
@@ -265,7 +265,7 @@ namespace FlaUI.Core.Input
             {
                 // An error occured
                 var errorCode = Marshal.GetLastWin32Error();
-                Logger.Default.Warn("Could not send keyboard input. ErrorCode: {0}", errorCode);
+                throw new Win32Exception(errorCode);
             }
         }
     }

--- a/src/FlaUI.Core/Input/Mouse.cs
+++ b/src/FlaUI.Core/Input/Mouse.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Permissions;
 using System.Threading;
-using FlaUI.Core.Logging;
 using FlaUI.Core.Tools;
 using FlaUI.Core.WindowsAPI;
 
@@ -382,7 +382,7 @@ namespace FlaUI.Core.Input
             {
                 // An error occured
                 var errorCode = Marshal.GetLastWin32Error();
-                Logger.Default.Warn("Could not send mouse input. ErrorCode: {0}", errorCode);
+                throw new Win32Exception(errorCode);
             }
         }
 


### PR DESCRIPTION
This would solve https://github.com/FlaUI/FlaUI/issues/437 for us. I adapted the code to throw an error like all the other places that check `GetLastWin32Error`.