### PR TITLE
Allow to skip logging missing frames info

### DIFF
--- a/src/FlaUI.Core/Capturing/VideoRecorder.cs
+++ b/src/FlaUI.Core/Capturing/VideoRecorder.cs
@@ -65,10 +65,11 @@ namespace FlaUI.Core.Capturing
                 {
                     var requiredFrames = (int)Math.Floor(sw.Elapsed.TotalSeconds * _settings.FrameRate);
                     var diff = requiredFrames - frameCount;
-                    if (diff >= 5)
+                    if (diff >= 5 && _settings.LogMissingFrames)
                     {
                         Logger.Default.Warn($"Adding many ({diff}) missing frame(s) to \"{Path.GetFileName(TargetVideoPath)}\".");
                     }
+
                     for (var i = 0; i < diff; ++i)
                     {
                         _frames.Add(ImageData.RepeatImage);
@@ -95,7 +96,7 @@ namespace FlaUI.Core.Capturing
                     await Task.Delay(timeTillNextFrame);
                 }
             }
-            if (totalMissedFrames > 0)
+            if (totalMissedFrames > 0 && _settings.LogMissingFrames)
             {
                 Logger.Default.Warn($"Totally added {totalMissedFrames} missing frame(s) to \"{Path.GetFileName(TargetVideoPath)}\".");
             }

--- a/src/FlaUI.Core/Capturing/VideoRecorderSettings.cs
+++ b/src/FlaUI.Core/Capturing/VideoRecorderSettings.cs
@@ -47,6 +47,11 @@ namespace FlaUI.Core.Capturing
         /// Run the encoding with low processor priority.
         /// </summary>
         public bool EncodeWithLowPriority { get; set; }
+
+        /// <summary>
+        /// If to log warning when recorder detects that there were missing frames. Default is <c>true</c>
+        /// </summary>
+        public bool LogMissingFrames { get; set; } = true;
     }
 }
 #endif


### PR DESCRIPTION
In our case it adds too much info in test logs, due to the high
framerate used.