### PR TITLE
Add screenshot to testresult for XML report

### DIFF
--- a/src/FlaUI.TestUtilities/FlaUITestBase.cs
+++ b/src/FlaUI.TestUtilities/FlaUITestBase.cs
@@ -64,7 +64,7 @@ namespace FlaUI.TestUtilities
         /// Path of the directory for the screenshots and videos for the tests.
         /// Defaults to c:\temp\testsmedia.
         /// </summary>
-        protected virtual string TestsMediaPath => $@"c:\temp\testsmedia\{TestContext.CurrentContext.Test.Name}\{_testDateTime}";
+        protected virtual string TestsMediaPath => $@"c:\temp\testsmedia\{SanitizeFileName(TestContext.CurrentContext.Test.Name)}\{_testDateTime}";
 
         /// <summary>
         /// Gets the automation instance that should be used.

--- a/src/FlaUI.TestUtilities/FlaUITestBase.cs
+++ b/src/FlaUI.TestUtilities/FlaUITestBase.cs
@@ -56,10 +56,15 @@ namespace FlaUI.TestUtilities
         protected virtual VideoRecordingMode VideoRecordingMode => VideoRecordingMode.OnePerTest;
 
         /// <summary>
+        /// static member which holds the current execution date and time
+        /// </summary> 
+        private static string _testDateTime = DateTime.Now.ToString("yyyyMMddHHmmss");
+
+        /// <summary>
         /// Path of the directory for the screenshots and videos for the tests.
         /// Defaults to c:\temp\testsmedia.
         /// </summary>
-        protected virtual string TestsMediaPath => @"c:\temp\testsmedia";
+        protected virtual string TestsMediaPath => $@"c:\temp\testsmedia\{TestContext.CurrentContext.Test.Name}\{_testDateTime}";
 
         /// <summary>
         /// Gets the automation instance that should be used.

--- a/src/FlaUI.TestUtilities/FlaUITestBase.cs
+++ b/src/FlaUI.TestUtilities/FlaUITestBase.cs
@@ -140,6 +140,9 @@ namespace FlaUI.TestUtilities
             if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
             {
                 TakeScreenShot(TestContext.CurrentContext.Test.FullName);
+                TestContext.AddTestAttachment(
+                    CreateScreenShotPath(TestContext.CurrentContext.Test.FullName),
+                    TestContext.CurrentContext.Test.FullName);
             }
 
             if (ApplicationStartMode == ApplicationStartMode.OncePerTest)
@@ -251,9 +254,7 @@ namespace FlaUI.TestUtilities
         /// </summary>
         private void TakeScreenShot(string testName)
         {
-            var imageName = SanitizeFileName(testName) + ".png";
-            imageName = imageName.Replace("\"", String.Empty);
-            var imagePath = Path.Combine(TestsMediaPath, imageName);
+            var imagePath = CreateScreenShotPath(testName);
             try
             {
                 Directory.CreateDirectory(TestsMediaPath);
@@ -272,6 +273,16 @@ namespace FlaUI.TestUtilities
         {
             fileName = string.Join("_", fileName.Split(Path.GetInvalidFileNameChars()));
             return fileName;
+        }
+        
+        /// <summary>
+        /// Generates full path for screenshot.
+        /// </summary>
+        private string CreateScreenShotPath(string testName)
+        {
+            var imageName = SanitizeFileName(testName) + ".png";
+            imageName = imageName.Replace("\"", String.Empty);
+            return Path.Combine(TestsMediaPath, imageName);
         }
     }
 }


### PR DESCRIPTION
[[L143-L145]](https://github.com/igorrecioh/FlaUI/blob/3dafb2092f333a6928eae6d2a9fbd8bad341440b/src/FlaUI.TestUtilities/FlaUITestBase.cs#L143-L145) I have added the AddTestAttachment method in order to include taken screenshot to the report and, therefore, the screenshot will be available in XML report, generated at the end of execution. This is interesting when parsing XML to generate, for example, an HTML report.

[[L278-L286]](https://github.com/igorrecioh/FlaUI/blob/3dafb2092f333a6928eae6d2a9fbd8bad341440b/src/FlaUI.TestUtilities/FlaUITestBase.cs#L278-L286) I have extracted from TakeScreenShot the generation of the full path so that I can use it in previously explained code.