### PR TITLE
Updated Retry to capture results after exception

### DIFF
--- a/src/FlaUI.Core/Tools/Retry.cs
+++ b/src/FlaUI.Core/Tools/Retry.cs
@@ -56,12 +56,13 @@ namespace FlaUI.Core.Tools
                 }
                 catch (Exception ex)
                 {
-                    if (!ignoreException)
-                    {
-                        throw;
-                    }
                     lastException = ex;
                     retryResult.SetException(ex);
+                    if (!ignoreException)
+                    {
+                        retryResult.Finish(lastValueOnTimeout ? lastValue : defaultOnTimeout, false);
+                        throw;
+                    }
                 }
                 Thread.Sleep(interval.Value);
             } while (!IsTimeoutReached(startTime, timeout.Value));


### PR DESCRIPTION
If an exception is thrown during a retry, retryResult will not save it. This fix will do it