### PR TITLE
Support nullable annotations

### DIFF
--- a/src/FlaUI.Core/ActionDisposable.cs
+++ b/src/FlaUI.Core/ActionDisposable.cs
@@ -8,7 +8,7 @@ namespace FlaUI.Core
     /// </summary>
     public class ActionDisposable : IDisposable
     {
-        private volatile Action disposeAction;
+        private volatile Action? disposeAction;
 
         /// <summary>
         /// Constructs a new disposable with the given action used for disposal.

--- a/src/FlaUI.Core/Application.cs
+++ b/src/FlaUI.Core/Application.cs
@@ -212,7 +212,7 @@ namespace FlaUI.Core
         /// </summary>
         /// <param name="executable">The executable to launch.</param>
         /// <param name="arguments">Arguments to executable</param>
-        public static Application Launch(string executable, string arguments = null)
+        public static Application Launch(string executable, string? arguments = null)
         {
             var processStartInfo = new ProcessStartInfo(executable, arguments);
             return Launch(processStartInfo);
@@ -238,7 +238,7 @@ namespace FlaUI.Core
             Process process;
             try
             {
-                process = Process.Start(processStartInfo);
+                process = Process.Start(processStartInfo)!;
             }
             catch (Win32Exception ex)
             {
@@ -260,7 +260,7 @@ namespace FlaUI.Core
         /// </summary>
         /// <param name="appUserModelId">The app id of the application to launch.</param>
         /// <param name="arguments">The arguments to pass to the application.</param>
-        public static Application LaunchStoreApp(string appUserModelId, string arguments = null)
+        public static Application LaunchStoreApp(string appUserModelId, string? arguments = null)
         {
             var process = WindowsStoreAppLauncher.Launch(appUserModelId, arguments);
             return new Application(process, true);
@@ -300,7 +300,7 @@ namespace FlaUI.Core
         /// <param name="automation">The automation object to use.</param>
         /// <param name="waitTimeout">An optional timeout. If null is passed, the timeout is infinite.</param>
         /// <returns>The main window object as <see cref="Window" /> or null if no main window was found within the timeout.</returns>
-        public Window GetMainWindow(AutomationBase automation, TimeSpan? waitTimeout = null)
+        public Window? GetMainWindow(AutomationBase automation, TimeSpan? waitTimeout = null)
         {
             WaitWhileMainHandleIsMissing(waitTimeout);
             var mainWindowHandle = MainWindowHandle;

--- a/src/FlaUI.Core/AutomationElements/AutomationElement.AsMethods.cs
+++ b/src/FlaUI.Core/AutomationElements/AutomationElement.AsMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using FlaUI.Core.AutomationElements.Scrolling;
 
 namespace FlaUI.Core.AutomationElements
@@ -8,7 +9,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Button"/>.
         /// </summary>
-        public static Button AsButton(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Button? AsButton(this AutomationElement? self)
         {
             return self == null ? null : new Button(self.FrameworkAutomationElement);
         }
@@ -16,7 +18,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Calendar"/>.
         /// </summary>
-        public static Calendar AsCalendar(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Calendar? AsCalendar(this AutomationElement? self)
         {
             return self == null ? null : new Calendar(self.FrameworkAutomationElement);
         }
@@ -24,7 +27,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="CheckBox"/>.
         /// </summary>
-        public static CheckBox AsCheckBox(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static CheckBox? AsCheckBox(this AutomationElement? self)
         {
             return self == null ? null : new CheckBox(self.FrameworkAutomationElement);
         }
@@ -32,7 +36,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="ComboBox"/>.
         /// </summary>
-        public static ComboBox AsComboBox(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static ComboBox? AsComboBox(this AutomationElement? self)
         {
             return self == null ? null : new ComboBox(self.FrameworkAutomationElement);
         }
@@ -40,7 +45,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="DataGridView"/>.
         /// </summary>
-        public static DataGridView AsDataGridView(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static DataGridView? AsDataGridView(this AutomationElement? self)
         {
             return self == null ? null : new DataGridView(self.FrameworkAutomationElement);
         }
@@ -48,7 +54,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="DateTimePicker"/>.
         /// </summary>
-        public static DateTimePicker AsDateTimePicker(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static DateTimePicker? AsDateTimePicker(this AutomationElement? self)
         {
             return self == null ? null : new DateTimePicker(self.FrameworkAutomationElement);
         }
@@ -56,7 +63,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Label"/>.
         /// </summary>
-        public static Label AsLabel(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Label? AsLabel(this AutomationElement? self)
         {
             return self == null ? null : new Label(self.FrameworkAutomationElement);
         }
@@ -64,7 +72,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Grid"/>.
         /// </summary>
-        public static Grid AsGrid(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Grid? AsGrid(this AutomationElement? self)
         {
             return self == null ? null : new Grid(self.FrameworkAutomationElement);
         }
@@ -72,7 +81,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="GridRow"/>.
         /// </summary>
-        public static GridRow AsGridRow(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static GridRow? AsGridRow(this AutomationElement? self)
         {
             return self == null ? null : new GridRow(self.FrameworkAutomationElement);
         }
@@ -80,7 +90,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="GridCell"/>.
         /// </summary>
-        public static GridCell AsGridCell(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static GridCell? AsGridCell(this AutomationElement? self)
         {
             return self == null ? null : new GridCell(self.FrameworkAutomationElement);
         }
@@ -88,7 +99,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="GridHeader"/>.
         /// </summary>
-        public static GridHeader AsGridHeader(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static GridHeader? AsGridHeader(this AutomationElement? self)
         {
             return self == null ? null : new GridHeader(self.FrameworkAutomationElement);
         }
@@ -96,7 +108,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="GridHeaderItem"/>.
         /// </summary>
-        public static GridHeaderItem AsGridHeaderItem(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static GridHeaderItem? AsGridHeaderItem(this AutomationElement? self)
         {
             return self == null ? null : new GridHeaderItem(self.FrameworkAutomationElement);
         }
@@ -104,7 +117,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="HorizontalScrollBar"/>.
         /// </summary>
-        public static HorizontalScrollBar AsHorizontalScrollBar(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static HorizontalScrollBar? AsHorizontalScrollBar(this AutomationElement? self)
         {
             return self == null ? null : new HorizontalScrollBar(self.FrameworkAutomationElement);
         }
@@ -112,7 +126,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="ListBox"/>.
         /// </summary>
-        public static ListBox AsListBox(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static ListBox? AsListBox(this AutomationElement? self)
         {
             return self == null ? null : new ListBox(self.FrameworkAutomationElement);
         }
@@ -120,7 +135,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="ListBoxItem"/>.
         /// </summary>
-        public static ListBoxItem AsListBoxItem(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static ListBoxItem? AsListBoxItem(this AutomationElement? self)
         {
             return self == null ? null : new ListBoxItem(self.FrameworkAutomationElement);
         }
@@ -128,7 +144,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Menu"/>.
         /// </summary>
-        public static Menu AsMenu(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Menu? AsMenu(this AutomationElement? self)
         {
             return self == null ? null : new Menu(self.FrameworkAutomationElement);
         }
@@ -136,7 +153,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="MenuItem"/>.
         /// </summary>
-        public static MenuItem AsMenuItem(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static MenuItem? AsMenuItem(this AutomationElement? self)
         {
             return self == null ? null : new MenuItem(self.FrameworkAutomationElement);
         }
@@ -144,7 +162,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="ProgressBar"/>.
         /// </summary>
-        public static ProgressBar AsProgressBar(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static ProgressBar? AsProgressBar(this AutomationElement? self)
         {
             return self == null ? null : new ProgressBar(self.FrameworkAutomationElement);
         }
@@ -152,7 +171,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="RadioButton"/>.
         /// </summary>
-        public static RadioButton AsRadioButton(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static RadioButton? AsRadioButton(this AutomationElement? self)
         {
             return self == null ? null : new RadioButton(self.FrameworkAutomationElement);
         }
@@ -160,7 +180,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Slider"/>.
         /// </summary>
-        public static Slider AsSlider(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Slider? AsSlider(this AutomationElement? self)
         {
             return self == null ? null : new Slider(self.FrameworkAutomationElement);
         }
@@ -168,7 +189,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Spinner"/>.
         /// </summary>
-        public static Spinner AsSpinner(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Spinner? AsSpinner(this AutomationElement? self)
         {
             return self == null ? null : new Spinner(self.FrameworkAutomationElement);
         }
@@ -176,7 +198,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Tab"/>.
         /// </summary>
-        public static Tab AsTab(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Tab? AsTab(this AutomationElement? self)
         {
             return self == null ? null : new Tab(self.FrameworkAutomationElement);
         }
@@ -184,7 +207,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="TabItem"/>.
         /// </summary>
-        public static TabItem AsTabItem(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static TabItem? AsTabItem(this AutomationElement? self)
         {
             return self == null ? null : new TabItem(self.FrameworkAutomationElement);
         }
@@ -192,7 +216,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="TextBox"/>.
         /// </summary>
-        public static TextBox AsTextBox(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static TextBox? AsTextBox(this AutomationElement? self)
         {
             return self == null ? null : new TextBox(self.FrameworkAutomationElement);
         }
@@ -200,7 +225,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Thumb"/>.
         /// </summary>
-        public static Thumb AsThumb(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Thumb? AsThumb(this AutomationElement? self)
         {
             return self == null ? null : new Thumb(self.FrameworkAutomationElement);
         }
@@ -208,7 +234,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="TitleBar"/>.
         /// </summary>
-        public static TitleBar AsTitleBar(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static TitleBar? AsTitleBar(this AutomationElement? self)
         {
             return self == null ? null : new TitleBar(self.FrameworkAutomationElement);
         }
@@ -216,7 +243,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="ToggleButton"/>.
         /// </summary>
-        public static ToggleButton AsToggleButton(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static ToggleButton? AsToggleButton(this AutomationElement? self)
         {
             return self == null ? null : new ToggleButton(self.FrameworkAutomationElement);
         }
@@ -224,7 +252,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Tree"/>.
         /// </summary>
-        public static Tree AsTree(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Tree? AsTree(this AutomationElement? self)
         {
             return self == null ? null : new Tree(self.FrameworkAutomationElement);
         }
@@ -232,7 +261,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="TreeItem"/>.
         /// </summary>
-        public static TreeItem AsTreeItem(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static TreeItem? AsTreeItem(this AutomationElement? self)
         {
             return self == null ? null : new TreeItem(self.FrameworkAutomationElement);
         }
@@ -240,7 +270,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="VerticalScrollBar"/>.
         /// </summary>
-        public static VerticalScrollBar AsVerticalScrollBar(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static VerticalScrollBar? AsVerticalScrollBar(this AutomationElement? self)
         {
             return self == null ? null : new VerticalScrollBar(self.FrameworkAutomationElement);
         }
@@ -248,7 +279,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Converts the element to a <see cref="Window"/>.
         /// </summary>
-        public static Window AsWindow(this AutomationElement self)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static Window? AsWindow(this AutomationElement? self)
         {
             return self == null ? null : new Window(self.FrameworkAutomationElement);
         }
@@ -256,22 +288,23 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Method to convert the element to the given type.
         /// </summary>
-        public static AutomationElement AsType(this AutomationElement self, Type type)
+        [return: NotNullIfNotNull(nameof(self))]
+        public static AutomationElement? AsType(this AutomationElement? self, Type type)
         {
             if (!type.IsAssignableFrom(typeof(AutomationElement)))
             {
                 throw new ArgumentException("The given type is not an AutomationElement", nameof(type));
             }
-            return self == null ? null : (AutomationElement)Activator.CreateInstance(type, self.FrameworkAutomationElement);
+            return self == null ? null : (AutomationElement)Activator.CreateInstance(type, self.FrameworkAutomationElement)!;
         }
 
         /// <summary>
         /// Generic method to convert the element to the given type.
         /// </summary>
-        public static T As<T>(this AutomationElement self) where T : AutomationElement
+        [return: NotNullIfNotNull(nameof(self))]
+        public static T? As<T>(this AutomationElement? self) where T : AutomationElement
         {
-            var type = typeof(T);
-            return self == null ? null : (T)Activator.CreateInstance(typeof(T), self.FrameworkAutomationElement);
+            return self == null ? null : (T)Activator.CreateInstance(typeof(T), self.FrameworkAutomationElement)!;
         }
     }
 }

--- a/src/FlaUI.Core/AutomationElements/AutomationElement.Find.cs
+++ b/src/FlaUI.Core/AutomationElements/AutomationElement.Find.cs
@@ -16,7 +16,7 @@ namespace FlaUI.Core.AutomationElements
         }
 
         /// <inheritdoc />
-        public AutomationElement FindFirst(TreeScope treeScope, ConditionBase condition)
+        public AutomationElement? FindFirst(TreeScope treeScope, ConditionBase condition)
         {
             return FrameworkAutomationElement.FindFirst(treeScope, condition);
         }
@@ -29,14 +29,14 @@ namespace FlaUI.Core.AutomationElements
         }
 
         /// <inheritdoc />
-        public AutomationElement FindFirstWithOptions(TreeScope treeScope, ConditionBase condition,
+        public AutomationElement? FindFirstWithOptions(TreeScope treeScope, ConditionBase condition,
             TreeTraversalOptions traversalOptions, AutomationElement root)
         {
             return FrameworkAutomationElement.FindFirstWithOptions(treeScope, condition, traversalOptions, root);
         }
 
         /// <inheritdoc />
-        public AutomationElement FindAt(TreeScope treeScope, int index, ConditionBase condition)
+        public AutomationElement? FindAt(TreeScope treeScope, int index, ConditionBase condition)
         {
             return FrameworkAutomationElement.FindAt(treeScope, index, condition);
         }
@@ -44,7 +44,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Finds the first element by iterating thru all conditions.
         /// </summary>
-        public AutomationElement FindFirstNested(params ConditionBase[] nestedConditions)
+        public AutomationElement? FindFirstNested(params ConditionBase[] nestedConditions)
         {
             var currentElement = this;
             foreach (var condition in nestedConditions)
@@ -61,7 +61,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Finds all elements by iterating thru all conditions.
         /// </summary>
-        public AutomationElement[] FindAllNested(params ConditionBase[] nestedConditions)
+        public AutomationElement[]? FindAllNested(params ConditionBase[] nestedConditions)
         {
             var currentElement = this;
             for (var i = 0; i < nestedConditions.Length - 1; i++)
@@ -79,11 +79,11 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Finds for the first item which matches the given xpath.
         /// </summary>
-        public AutomationElement FindFirstByXPath(string xPath)
+        public AutomationElement? FindFirstByXPath(string xPath)
         {
             var xPathNavigator = new AutomationElementXPathNavigator(this);
             var nodeItem = xPathNavigator.SelectSingleNode(xPath);
-            return (AutomationElement)nodeItem?.UnderlyingObject;
+            return (AutomationElement?)nodeItem?.UnderlyingObject;
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace FlaUI.Core.AutomationElements
         /// Finds the first child.
         /// </summary>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindFirstChild()
+        public AutomationElement? FindFirstChild()
         {
             return FindFirst(TreeScope.Children, TrueCondition.Default);
         }
@@ -116,7 +116,7 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="automationId">The automation id.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindFirstChild(string automationId)
+        public AutomationElement? FindFirstChild(string automationId)
         {
             return FindFirst(TreeScope.Children, ConditionFactory.ByAutomationId(automationId));
         }
@@ -126,7 +126,7 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="condition">The condition.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindFirstChild(ConditionBase condition)
+        public AutomationElement? FindFirstChild(ConditionBase condition)
         {
             return FindFirst(TreeScope.Children, condition);
         }
@@ -136,7 +136,7 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="conditionFunc">The condition method.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindFirstChild(Func<ConditionFactory, ConditionBase> conditionFunc)
+        public AutomationElement? FindFirstChild(Func<ConditionFactory, ConditionBase> conditionFunc)
         {
             var condition = conditionFunc(ConditionFactory);
             return FindFirstChild(condition);
@@ -176,7 +176,7 @@ namespace FlaUI.Core.AutomationElements
         /// Finds the first descendant.
         /// </summary>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindFirstDescendant()
+        public AutomationElement? FindFirstDescendant()
         {
             return FindFirst(TreeScope.Descendants, TrueCondition.Default);
         }
@@ -186,7 +186,7 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="automationId">The automation id.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindFirstDescendant(string automationId)
+        public AutomationElement? FindFirstDescendant(string automationId)
         {
             return FindFirst(TreeScope.Descendants, ConditionFactory.ByAutomationId(automationId));
         }
@@ -196,7 +196,7 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="condition">The condition.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindFirstDescendant(ConditionBase condition)
+        public AutomationElement? FindFirstDescendant(ConditionBase condition)
         {
             return FindFirst(TreeScope.Descendants, condition);
         }
@@ -206,7 +206,7 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="conditionFunc">The condition method.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindFirstDescendant(Func<ConditionFactory, ConditionBase> conditionFunc)
+        public AutomationElement? FindFirstDescendant(Func<ConditionFactory, ConditionBase> conditionFunc)
         {
             var condition = conditionFunc(ConditionFactory);
             return FindFirstDescendant(condition);
@@ -247,7 +247,7 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="conditionFunc">The condition method.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindFirstNested(Func<ConditionFactory, IList<ConditionBase>> conditionFunc)
+        public AutomationElement? FindFirstNested(Func<ConditionFactory, IList<ConditionBase>> conditionFunc)
         {
             var conditions = conditionFunc(ConditionFactory);
             return FindFirstNested(conditions.ToArray());
@@ -258,7 +258,7 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="conditionFunc">The condition method.</param>
         /// <returns>The found elements or an empty list if no elements were found.</returns>
-        public AutomationElement[] FindAllNested(Func<ConditionFactory, IList<ConditionBase>> conditionFunc)
+        public AutomationElement[]? FindAllNested(Func<ConditionFactory, IList<ConditionBase>> conditionFunc)
         {
             var conditions = conditionFunc(ConditionFactory);
             return FindAllNested(conditions.ToArray());
@@ -270,7 +270,7 @@ namespace FlaUI.Core.AutomationElements
         /// <param name="index">The index of the child to find.</param>
         /// <param name="condition">The condition.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindChildAt(int index, ConditionBase condition = null)
+        public AutomationElement? FindChildAt(int index, ConditionBase? condition = null)
         {
             return FindAt(TreeScope.Children, index, condition ?? TrueCondition.Default);
         }
@@ -281,7 +281,7 @@ namespace FlaUI.Core.AutomationElements
         /// <param name="index">The index of the child to find.</param>
         /// <param name="conditionFunc">The condition method.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        public AutomationElement FindChildAt(int index, Func<ConditionFactory, ConditionBase> conditionFunc)
+        public AutomationElement? FindChildAt(int index, Func<ConditionFactory, ConditionBase> conditionFunc)
         {
             var condition = conditionFunc(ConditionFactory);
             return FindChildAt(index, condition);

--- a/src/FlaUI.Core/AutomationElements/AutomationElement.cs
+++ b/src/FlaUI.Core/AutomationElements/AutomationElement.cs
@@ -31,8 +31,11 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="automationElement">The <see cref="AutomationElement"/> which <see cref="FrameworkAutomationElement"/> should be wrapped.</param>
         public AutomationElement(AutomationElement automationElement)
-            : this(automationElement?.FrameworkAutomationElement)
         {
+            if (automationElement == null)
+                throw new ArgumentNullException(nameof(automationElement));
+
+            FrameworkAutomationElement = automationElement.FrameworkAutomationElement;
         }
 
         /// <summary>
@@ -109,8 +112,9 @@ namespace FlaUI.Core.AutomationElements
         {
             get
             {
-                var hasProperty = Properties.FrameworkId.TryGetValue(out string currentFrameworkId);
-                return hasProperty ? FrameworkIds.Convert(currentFrameworkId) : FrameworkType.Unknown;
+                return Properties.FrameworkId.TryGetValue(out var currentFrameworkId)
+                    ? FrameworkIds.Convert(currentFrameworkId)
+                    : FrameworkType.Unknown;
             }
         }
 
@@ -443,13 +447,13 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Compares two elements.
         /// </summary>
-        public bool Equals(AutomationElement other)
+        public bool Equals(AutomationElement? other)
         {
             return other != null && Automation.Compare(this, other);
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as AutomationElement);
         }
@@ -498,7 +502,7 @@ namespace FlaUI.Core.AutomationElements
         /// <param name="throwIfNotSupported">Flag to indicate if an exception should be thrown if the pattern is not supported.</param>
         /// <param name="func">The function to execute on the pattern.</param>
         /// <returns>The value received from the pattern or the default if the pattern is not supported.</returns>
-        protected internal TRet ExecuteInPattern<TPattern, TRet>(TPattern pattern, bool throwIfNotSupported, Func<TPattern, TRet> func)
+        protected internal TRet? ExecuteInPattern<TPattern, TRet>(TPattern pattern, bool throwIfNotSupported, Func<TPattern, TRet> func)
         {
             if (pattern != null)
             {

--- a/src/FlaUI.Core/AutomationElements/AutomationElementExtensions.cs
+++ b/src/FlaUI.Core/AutomationElements/AutomationElementExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using FlaUI.Core.Tools;
 
@@ -56,7 +57,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Waits until the element has a clickable point.
         /// </summary>
-        public static T WaitUntilClickable<T>(this T self, TimeSpan? timeout = null) where T : AutomationElement
+        [return: NotNullIfNotNull(nameof(self))]
+        public static T? WaitUntilClickable<T>(this T? self, TimeSpan? timeout = null) where T : AutomationElement
         {
             if (self != null)
             {
@@ -68,7 +70,8 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Waits until the element is enabled.
         /// </summary>
-        public static T WaitUntilEnabled<T>(this T self, TimeSpan? timeout = null) where T : AutomationElement
+        [return: NotNullIfNotNull(nameof(self))]
+        public static T? WaitUntilEnabled<T>(this T? self, TimeSpan? timeout = null) where T : AutomationElement
         {
             if (self != null)
             {

--- a/src/FlaUI.Core/AutomationElements/ComboBox.cs
+++ b/src/FlaUI.Core/AutomationElements/ComboBox.cs
@@ -31,7 +31,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Pattern object for the <see cref="ISelectionPattern"/>.
         /// </summary>
-        protected ISelectionPattern SelectionPattern => Patterns.Selection.PatternOrDefault;
+        protected ISelectionPattern? SelectionPattern => Patterns.Selection.PatternOrDefault;
 
         /// <summary>
         /// The text of the editable element inside the combobox.
@@ -125,7 +125,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the first selected item or null otherwise.
         /// </summary>
-        public ComboBoxItem SelectedItem => SelectedItems?.FirstOrDefault();
+        public ComboBoxItem? SelectedItem => SelectedItems.FirstOrDefault();
 
         /// <summary>
         /// Gets all items.
@@ -140,7 +140,7 @@ namespace FlaUI.Core.AutomationElements
                 {
                     // WinForms and Win32
                     var listElement = FindFirstChild(cf => cf.ByControlType(ControlType.List));
-                    items = listElement.FindAllChildren();
+                    items = listElement?.FindAllChildren() ?? Array.Empty<AutomationElement>();
                 }
                 else
                 {
@@ -188,7 +188,7 @@ namespace FlaUI.Core.AutomationElements
             if (FrameworkType == FrameworkType.WinForms)
             {
                 // WinForms
-                var openButton = FindFirstChild(cf => cf.ByControlType(ControlType.Button)).AsButton();
+                var openButton = FindFirstChild(cf => cf.ByControlType(ControlType.Button))!.AsButton();
                 openButton.Invoke();
             }
             else
@@ -213,7 +213,7 @@ namespace FlaUI.Core.AutomationElements
             if (FrameworkType == FrameworkType.WinForms)
             {
                 // WinForms
-                var openButton = FindFirstChild(cf => cf.ByControlType(ControlType.Button)).AsButton();
+                var openButton = FindFirstChild(cf => cf.ByControlType(ControlType.Button))!.AsButton();
                 if (IsEditable)
                 {
                     // WinForms editable combo box only closes on click and not on invoke
@@ -249,14 +249,14 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         /// <param name="textToFind">The text to search for.</param>
         /// <returns>The first found item or null if no item matches.</returns>
-        public ComboBoxItem Select(string textToFind)
+        public ComboBoxItem? Select(string textToFind)
         {
             var foundItem = Items.FirstOrDefault(item => item.Text.Equals(textToFind));
             foundItem?.Select();
             return foundItem;
         }
 
-        private AutomationElement GetEditableElement()
+        private AutomationElement? GetEditableElement()
         {
             return FindFirstChild(cf => cf.ByControlType(ControlType.Edit));
         }

--- a/src/FlaUI.Core/AutomationElements/DataGridView.cs
+++ b/src/FlaUI.Core/AutomationElements/DataGridView.cs
@@ -26,7 +26,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the header element or null if the header is disabled.
         /// </summary>
-        public virtual DataGridViewHeader Header
+        public virtual DataGridViewHeader? Header
         {
             get
             {

--- a/src/FlaUI.Core/AutomationElements/Grid.cs
+++ b/src/FlaUI.Core/AutomationElements/Grid.cs
@@ -62,7 +62,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the header item.
         /// </summary>
-        public virtual GridHeader Header
+        public virtual GridHeader? Header
         {
             get
             {
@@ -92,72 +92,72 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the first selected item or null otherwise.
         /// </summary>
-        public GridRow SelectedItem => SelectedItems?.FirstOrDefault();
+        public GridRow? SelectedItem => SelectedItems.FirstOrDefault();
 
         /// <summary>
         /// Select a row by index.
         /// </summary>
-        public GridRow Select(int rowIndex)
+        public GridRow? Select(int rowIndex)
         {
             var gridRow = GetRowByIndex(rowIndex);
-            gridRow.Select();
+            gridRow?.Select();
             return gridRow;
         }
 
         /// <summary>
         /// Select the first row by text in the given column.
         /// </summary>
-        public GridRow Select(int columnIndex, string textToFind)
+        public GridRow? Select(int columnIndex, string textToFind)
         {
             var gridRow = GetRowByValue(columnIndex, textToFind);
-            gridRow.Select();
+            gridRow?.Select();
             return gridRow;
         }
 
         /// <summary>
         /// Add a row to the selection by index.
         /// </summary>
-        public GridRow AddToSelection(int rowIndex)
+        public GridRow? AddToSelection(int rowIndex)
         {
             var gridRow = GetRowByIndex(rowIndex);
-            gridRow.AddToSelection();
+            gridRow?.AddToSelection();
             return gridRow;
         }
 
         /// <summary>
         /// Add a row to the selection by text in the given column.
         /// </summary>
-        public GridRow AddToSelection(int columnIndex, string textToFind)
+        public GridRow? AddToSelection(int columnIndex, string textToFind)
         {
             var gridRow = GetRowByValue(columnIndex, textToFind);
-            gridRow.AddToSelection();
+            gridRow?.AddToSelection();
             return gridRow;
         }
 
         /// <summary>
         /// Remove a row from the selection by index.
         /// </summary>
-        public GridRow RemoveFromSelection(int rowIndex)
+        public GridRow? RemoveFromSelection(int rowIndex)
         {
             var gridRow = GetRowByIndex(rowIndex);
-            gridRow.RemoveFromSelection();
+            gridRow?.RemoveFromSelection();
             return gridRow;
         }
 
         /// <summary>
         /// Remove a row from the selection by text in the given column.
         /// </summary>
-        public GridRow RemoveFromSelection(int columnIndex, string textToFind)
+        public GridRow? RemoveFromSelection(int columnIndex, string textToFind)
         {
             var gridRow = GetRowByValue(columnIndex, textToFind);
-            gridRow.RemoveFromSelection();
+            gridRow?.RemoveFromSelection();
             return gridRow;
         }
 
         /// <summary>
         /// Get a row by index.
         /// </summary>
-        public GridRow GetRowByIndex(int rowIndex)
+        public GridRow? GetRowByIndex(int rowIndex)
         {
             PreCheckRow(rowIndex);
             var gridCell = GridPattern.GetItem(rowIndex, 0).AsGridCell();
@@ -167,7 +167,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Get a row by text in the given column.
         /// </summary>
-        public GridRow GetRowByValue(int columnIndex, string value)
+        public GridRow? GetRowByValue(int columnIndex, string value)
         {
             return GetRowsByValue(columnIndex, value, 1).FirstOrDefault();
         }
@@ -291,7 +291,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the header item of the row.
         /// </summary>
-        public GridHeaderItem Header
+        public GridHeaderItem? Header
         {
             get
             {
@@ -303,7 +303,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Find a cell by a given text.
         /// </summary>
-        public GridCell FindCellByText(string textToFind)
+        public GridCell? FindCellByText(string textToFind)
         {
             return Cells.FirstOrDefault(cell => cell.Value.Equals(textToFind));
         }
@@ -348,7 +348,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the row that contains this cell.
         /// </summary>
-        public GridRow ContainingRow
+        public GridRow? ContainingRow
         {
             get
             {

--- a/src/FlaUI.Core/AutomationElements/Infrastructure/IAutomationElementFinder.cs
+++ b/src/FlaUI.Core/AutomationElements/Infrastructure/IAutomationElementFinder.cs
@@ -22,7 +22,7 @@ namespace FlaUI.Core.AutomationElements.Infrastructure
         /// <param name="treeScope">The scope to search.</param>
         /// <param name="condition">The condition to use.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        AutomationElement FindFirst(TreeScope treeScope, ConditionBase condition);
+        AutomationElement? FindFirst(TreeScope treeScope, ConditionBase condition);
 
         /// <summary>
         /// Find all matching elements in the specified order.
@@ -42,7 +42,7 @@ namespace FlaUI.Core.AutomationElements.Infrastructure
         /// <param name="traversalOptions">Value specifying the tree navigation order.</param>
         /// <param name="root">An element with which to begin the search.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        AutomationElement FindFirstWithOptions(TreeScope treeScope, ConditionBase condition, TreeTraversalOptions traversalOptions, AutomationElement root);
+        AutomationElement? FindFirstWithOptions(TreeScope treeScope, ConditionBase condition, TreeTraversalOptions traversalOptions, AutomationElement root);
 
         /// <summary>
         /// Finds the element with the given index with the given condition.
@@ -51,6 +51,6 @@ namespace FlaUI.Core.AutomationElements.Infrastructure
         /// <param name="index">The index of the element to return (0-based).</param>
         /// <param name="condition">The condition to use.</param>
         /// <returns>The found element or null if no element was found.</returns>
-        AutomationElement FindAt(TreeScope treeScope, int index, ConditionBase condition);
+        AutomationElement? FindAt(TreeScope treeScope, int index, ConditionBase condition);
     }
 }

--- a/src/FlaUI.Core/AutomationElements/ListBox.cs
+++ b/src/FlaUI.Core/AutomationElements/ListBox.cs
@@ -33,7 +33,7 @@ namespace FlaUI.Core.AutomationElements
                 if (FrameworkType == FrameworkType.Wpf && Patterns.ItemContainer.TryGetPattern(out var itemContainerPattern))
                 {
                     List<ListBoxItem> allItems = new List<ListBoxItem>();
-                    AutomationElement item = null;
+                    AutomationElement? item = null;
                     do
                     {
                         item = itemContainerPattern.FindItemByProperty(item, null, null);
@@ -60,7 +60,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the first selected item or null otherwise.
         /// </summary>
-        public ListBoxItem SelectedItem => SelectionPattern.Selection.Value.FirstOrDefault()?.AsListBoxItem();
+        public ListBoxItem? SelectedItem => SelectionPattern.Selection.Value.FirstOrDefault()?.AsListBoxItem();
 
         /// <summary>
         /// Selects an item by index.
@@ -82,7 +82,7 @@ namespace FlaUI.Core.AutomationElements
             {
                 if (FrameworkType == FrameworkType.Wpf && Patterns.ItemContainer.TryGetPattern(out var itemContainerPattern))
                 {
-                    AutomationElement foundItem = itemContainerPattern.FindItemByProperty(null, FrameworkAutomationElement.PropertyIdLibrary.Name, text);
+                    AutomationElement? foundItem = itemContainerPattern.FindItemByProperty(null, FrameworkAutomationElement.PropertyIdLibrary.Name, text);
                     if (foundItem != null)
                     {
                         item = foundItem.AsListBoxItem();
@@ -117,7 +117,7 @@ namespace FlaUI.Core.AutomationElements
             {
                 if (FrameworkType == FrameworkType.Wpf && Patterns.ItemContainer.TryGetPattern(out var itemContainerPattern))
                 {
-                    AutomationElement foundItem = itemContainerPattern.FindItemByProperty(null, FrameworkAutomationElement.PropertyIdLibrary.Name, text);
+                    AutomationElement? foundItem = itemContainerPattern.FindItemByProperty(null, FrameworkAutomationElement.PropertyIdLibrary.Name, text);
                     if (foundItem != null)
                     {
                         item = foundItem.AsListBoxItem();
@@ -152,7 +152,7 @@ namespace FlaUI.Core.AutomationElements
             {
                 if (FrameworkType == FrameworkType.Wpf && Patterns.ItemContainer.TryGetPattern(out var itemContainerPattern))
                 {
-                    AutomationElement foundItem = itemContainerPattern.FindItemByProperty(null, FrameworkAutomationElement.PropertyIdLibrary.Name, text);
+                    AutomationElement? foundItem = itemContainerPattern.FindItemByProperty(null, FrameworkAutomationElement.PropertyIdLibrary.Name, text);
                     if (foundItem != null)
                     {
                         item = foundItem.AsListBoxItem();

--- a/src/FlaUI.Core/AutomationElements/Scrolling/HorizontalScrollBar.cs
+++ b/src/FlaUI.Core/AutomationElements/Scrolling/HorizontalScrollBar.cs
@@ -123,7 +123,7 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// </summary>
         public virtual void ScrollLeft()
         {
-            SmallDecrementButton.Click();
+            SmallDecrementButton?.Click();
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// </summary>
         public virtual void ScrollRight()
         {
-            SmallIncrementButton.Click();
+            SmallIncrementButton?.Click();
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// </summary>
         public virtual void ScrollLeftLarge()
         {
-            LargeDecrementButton.Click();
+            LargeDecrementButton?.Click();
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// </summary>
         public virtual void ScrollRightLarge()
         {
-            LargeIncrementButton.Click();
+            LargeIncrementButton?.Click();
         }
     }
 }

--- a/src/FlaUI.Core/AutomationElements/Scrolling/ScrollBarBase.cs
+++ b/src/FlaUI.Core/AutomationElements/Scrolling/ScrollBarBase.cs
@@ -23,27 +23,27 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// <summary>
         /// The <see cref="Button"/> used to scroll by a small decrement.
         /// </summary>
-        protected Button SmallDecrementButton => FindButton(SmallDecrementText);
+        protected Button? SmallDecrementButton => FindButton(SmallDecrementText);
 
         /// <summary>
         /// The <see cref="Button"/> used to scroll by a small increment.
         /// </summary>
-        protected Button SmallIncrementButton => FindButton(SmallIncrementText);
+        protected Button? SmallIncrementButton => FindButton(SmallIncrementText);
 
         /// <summary>
         /// The <see cref="Button"/> used to scroll by a large decrement.
         /// </summary>
-        protected Button LargeDecrementButton => FindButton(LargeDecrementText);
+        protected Button? LargeDecrementButton => FindButton(LargeDecrementText);
 
         /// <summary>
         /// The <see cref="Button"/> used to scroll by a large increment.
         /// </summary>
-        protected Button LargeIncrementButton => FindButton(LargeIncrementText);
+        protected Button? LargeIncrementButton => FindButton(LargeIncrementText);
 
         /// <summary>
         /// The <see cref="Thumb"/> used to scroll with dragging.
         /// </summary>
-        protected Thumb Thumb => FindThumb();
+        protected Thumb? Thumb => FindThumb();
 
         /// <summary>
         /// The current value of the scroll.
@@ -95,13 +95,13 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// </summary>
         protected abstract string LargeIncrementText { get; }
 
-        private Button FindButton(string automationId)
+        private Button? FindButton(string automationId)
         {
             var button = FindFirstChild(cf => cf.ByControlType(ControlType.Button).And(cf.ByAutomationId(automationId)));
             return button?.AsButton();
         }
 
-        private Thumb FindThumb()
+        private Thumb? FindThumb()
         {
             var thumb = FindFirstChild(cf => cf.ByControlType(ControlType.Thumb));
             return thumb?.AsThumb();

--- a/src/FlaUI.Core/AutomationElements/Scrolling/VerticalScrollBar.cs
+++ b/src/FlaUI.Core/AutomationElements/Scrolling/VerticalScrollBar.cs
@@ -123,7 +123,7 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// </summary>
         public void ScrollUp()
         {
-            SmallDecrementButton.Invoke();
+            SmallDecrementButton?.Invoke();
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// </summary>
         public void ScrollDown()
         {
-            SmallIncrementButton.Invoke();
+            SmallIncrementButton?.Invoke();
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// </summary>
         public void ScrollUpLarge()
         {
-            LargeDecrementButton.Invoke();
+            LargeDecrementButton?.Invoke();
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace FlaUI.Core.AutomationElements.Scrolling
         /// </summary>
         public void ScrollDownLarge()
         {
-            LargeIncrementButton.Invoke();
+            LargeIncrementButton?.Invoke();
         }
     }
 }

--- a/src/FlaUI.Core/AutomationElements/Slider.cs
+++ b/src/FlaUI.Core/AutomationElements/Slider.cs
@@ -19,9 +19,9 @@ namespace FlaUI.Core.AutomationElements
         {
         }
 
-        private IRangeValuePattern RangeValuePattern => Patterns.RangeValue.PatternOrDefault;
+        private IRangeValuePattern? RangeValuePattern => Patterns.RangeValue.PatternOrDefault;
 
-        private IValuePattern ValuePattern => Patterns.Value.PatternOrDefault;
+        private IValuePattern? ValuePattern => Patterns.Value.PatternOrDefault;
 
         /// <summary>
         /// The minimum value.
@@ -46,17 +46,17 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// The button element used to perform a large increment.
         /// </summary>
-        public Button LargeIncreaseButton => GetLargeIncreaseButton();
+        public Button? LargeIncreaseButton => GetLargeIncreaseButton();
 
         /// <summary>
         /// The button element used to perform a large decrement.
         /// </summary>
-        public Button LargeDecreaseButton => GetLargeDecreaseButton();
+        public Button? LargeDecreaseButton => GetLargeDecreaseButton();
 
         /// <summary>
         /// The element used to drag.
         /// </summary>
-        public Thumb Thumb => FindFirstChild(cf => cf.ByControlType(ControlType.Thumb))?.AsThumb();
+        public Thumb? Thumb => FindFirstChild(cf => cf.ByControlType(ControlType.Thumb))?.AsThumb();
 
         /// <summary>
         /// Flag which indicates if the <see cref="Slider"/> supports range values (min->max) or only values (0-100).
@@ -106,7 +106,7 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         public void LargeIncrement()
         {
-            LargeIncreaseButton.Invoke();
+            LargeIncreaseButton?.Invoke();
         }
 
         /// <summary>
@@ -114,10 +114,10 @@ namespace FlaUI.Core.AutomationElements
         /// </summary>
         public void LargeDecrement()
         {
-            LargeDecreaseButton.Invoke();
+            LargeDecreaseButton?.Invoke();
         }
 
-        private Button GetLargeIncreaseButton()
+        private Button? GetLargeIncreaseButton()
         {
             if (FrameworkType == FrameworkType.Wpf)
             {
@@ -128,7 +128,7 @@ namespace FlaUI.Core.AutomationElements
             var buttons = FindAllChildren(cf => cf.ByControlType(ControlType.Button));
             foreach (var button in buttons)
             {
-                if (button.Properties.BoundingRectangle.Value.Left > Thumb.Properties.BoundingRectangle.Value.Left)
+                if (button.Properties.BoundingRectangle.Value.Left > Thumb?.Properties.BoundingRectangle.Value.Left)
                 {
                     return button.AsButton();
                 }
@@ -136,7 +136,7 @@ namespace FlaUI.Core.AutomationElements
             return null;
         }
 
-        private Button GetLargeDecreaseButton()
+        private Button? GetLargeDecreaseButton()
         {
             if (FrameworkType == FrameworkType.Wpf)
             {
@@ -147,7 +147,7 @@ namespace FlaUI.Core.AutomationElements
             var buttons = FindAllChildren(cf => cf.ByControlType(ControlType.Button));
             foreach (var button in buttons)
             {
-                if (button.Properties.BoundingRectangle.Value.Right < Thumb.Properties.BoundingRectangle.Value.Right)
+                if (button.Properties.BoundingRectangle.Value.Right < Thumb?.Properties.BoundingRectangle.Value.Right)
                 {
                     return button.AsButton();
                 }

--- a/src/FlaUI.Core/AutomationElements/Spinner.cs
+++ b/src/FlaUI.Core/AutomationElements/Spinner.cs
@@ -22,9 +22,9 @@ namespace FlaUI.Core.AutomationElements
         {
         }
 
-        private IRangeValuePattern RangeValuePattern => Patterns.RangeValue.PatternOrDefault;
+        private IRangeValuePattern? RangeValuePattern => Patterns.RangeValue.PatternOrDefault;
 
-        private IValuePattern ValuePattern => Patterns.Value.PatternOrDefault;
+        private IValuePattern? ValuePattern => Patterns.Value.PatternOrDefault;
 
         /// <summary>
         /// The minimum value.
@@ -44,12 +44,12 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// The button element used to perform a large increment.
         /// </summary>
-        public Button IncreaseButton => GetIncreaseButton();
+        public Button? IncreaseButton => GetIncreaseButton();
 
         /// <summary>
         /// The button element used to perform a large decrement.
         /// </summary>
-        public Button DecreaseButton => GetDecreaseButton();
+        public Button? DecreaseButton => GetDecreaseButton();
 
         /// <summary>
         /// Flag which indicates if the <see cref="Spinner"/> supports range values (min->max) or only values (0-100).
@@ -178,14 +178,14 @@ namespace FlaUI.Core.AutomationElements
         {
             if (AutomationType == AutomationType.UIA2)
             {
-                IncreaseButton.Invoke();
+                IncreaseButton?.Invoke();
                 Wait.UntilInputIsProcessed();
             }
             else // UIA3
             {
                 SetForeground();
                 Wait.UntilInputIsProcessed();
-                IncreaseButton.Click();
+                IncreaseButton?.Click();
                 Wait.UntilInputIsProcessed();
             }
         }
@@ -197,14 +197,14 @@ namespace FlaUI.Core.AutomationElements
         {
             if (AutomationType == AutomationType.UIA2)
             {
-                DecreaseButton.Invoke();
+                DecreaseButton?.Invoke();
                 Wait.UntilInputIsProcessed();
             }
             else // UIA3
             {
                 SetForeground();
                 Wait.UntilInputIsProcessed();
-                DecreaseButton.Click();
+                DecreaseButton?.Click();
                 Wait.UntilInputIsProcessed();
             }
         }
@@ -212,7 +212,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Method to get the increase button.
         /// </summary>
-        protected virtual Button GetIncreaseButton()
+        protected virtual Button? GetIncreaseButton()
         {
             var buttons = FindAllDescendants(cf => cf.ByControlType(ControlType.Button));
             return buttons.Length >= 1 ? buttons[0].AsButton() : null;
@@ -221,7 +221,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Method to get the decrease button.
         /// </summary>
-        protected virtual Button GetDecreaseButton()
+        protected virtual Button? GetDecreaseButton()
         {
             var buttons = FindAllDescendants(cf => cf.ByControlType(ControlType.Button));
             return buttons.Length >= 2 ? buttons[1].AsButton() : null;

--- a/src/FlaUI.Core/AutomationElements/TitleBar.cs
+++ b/src/FlaUI.Core/AutomationElements/TitleBar.cs
@@ -17,24 +17,24 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the minimize button element.
         /// </summary>
-        public Button MinimizeButton => FindButton("Minimize");
+        public Button? MinimizeButton => FindButton("Minimize");
 
         /// <summary>
         /// Gets the maximize button element.
         /// </summary>
-        public Button MaximizeButton => FindButton("Maximize");
+        public Button? MaximizeButton => FindButton("Maximize");
 
         /// <summary>
         /// Gets the restore button element.
         /// </summary>
-        public Button RestoreButton => FindButton("Restore");
+        public Button? RestoreButton => FindButton("Restore");
 
         /// <summary>
         /// Gets the close button element.
         /// </summary>
-        public Button CloseButton => FindButton("Close");
+        public Button? CloseButton => FindButton("Close");
 
-        private Button FindButton(string automationId)
+        private Button? FindButton(string automationId)
         {
             var buttonElement = FindFirstChild(cf => cf.ByControlType(ControlType.Button).And(cf.ByAutomationId(automationId)));
             return buttonElement?.AsButton();

--- a/src/FlaUI.Core/AutomationElements/Tree.cs
+++ b/src/FlaUI.Core/AutomationElements/Tree.cs
@@ -18,9 +18,9 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// The currently selected <see cref="TreeItem" />
         /// </summary>
-        public TreeItem SelectedTreeItem => SearchSelectedItem(Items);
+        public TreeItem? SelectedTreeItem => SearchSelectedItem(Items);
 
-        private TreeItem SearchSelectedItem(TreeItem[] treeItems)
+        private TreeItem? SearchSelectedItem(TreeItem[] treeItems)
         {
             // Search for a selected item in the direct children
             var directSelectedItem = treeItems.FirstOrDefault(t => t.IsSelected);

--- a/src/FlaUI.Core/AutomationElements/Window.cs
+++ b/src/FlaUI.Core/AutomationElements/Window.cs
@@ -35,7 +35,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the <see cref="TitleBar"/> of the window.
         /// </summary>
-        public TitleBar TitleBar => FindFirstChild(cf => cf.ByControlType(ControlType.TitleBar))?.AsTitleBar();
+        public TitleBar? TitleBar => FindFirstChild(cf => cf.ByControlType(ControlType.TitleBar))?.AsTitleBar();
 
         /// <summary>
         /// Flag to indicate, if the window is the application's main window.
@@ -60,7 +60,7 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the current WPF popup window.
         /// </summary>
-        public Window Popup
+        public Window? Popup
         {
             get
             {
@@ -74,12 +74,12 @@ namespace FlaUI.Core.AutomationElements
         /// Gets the context menu for the window.
         /// Note: It uses the FrameworkType of the window as lookup logic. Use <see cref="GetContextMenuByFrameworkType" /> if you want to control this.
         /// </summary>
-        public Menu ContextMenu => GetContextMenuByFrameworkType(FrameworkType);
+        public Menu? ContextMenu => GetContextMenuByFrameworkType(FrameworkType);
 
         /// <summary>
         /// Gets the context menu by a given <see cref="FrameworkType"/>.
         /// </summary>
-        public Menu GetContextMenuByFrameworkType(FrameworkType frameworkType)
+        public Menu? GetContextMenuByFrameworkType(FrameworkType frameworkType)
         {
             if (frameworkType == FrameworkType.Win32)
             {
@@ -106,7 +106,7 @@ namespace FlaUI.Core.AutomationElements
             {
                 // In WPF, there is a window (Popup) where the menu is inside
                 var popup = Popup;
-                var ctxMenu = popup.FindFirstChild(cf => cf.ByControlType(ControlType.Menu));
+                var ctxMenu = popup?.FindFirstChild(cf => cf.ByControlType(ControlType.Menu));
                 return ctxMenu.AsMenu();
             }
             // No menu found

--- a/src/FlaUI.Core/AutomationPattern.cs
+++ b/src/FlaUI.Core/AutomationPattern.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using FlaUI.Core.Identifiers;
 using FlaUI.Core.Patterns.Infrastructure;
 
@@ -18,14 +19,14 @@ namespace FlaUI.Core
         /// <summary>
         /// Gets the pattern or null if it is not supported.
         /// </summary>
-        T PatternOrDefault { get; }
+        T? PatternOrDefault { get; }
 
         /// <summary>
         /// Tries getting the pattern.
         /// </summary>
         /// <param name="pattern">The found pattern or null if it is not supported.</param>
         /// <returns>True if the pattern is supported, false otherwise.</returns>
-        bool TryGetPattern(out T pattern);
+        bool TryGetPattern([NotNullWhen(true)] out T? pattern);
 
         /// <summary>
         /// Gets a boolean value which indicates, if the pattern is supported.
@@ -70,19 +71,19 @@ namespace FlaUI.Core
         }
 
         /// <inheritdoc />
-        public T PatternOrDefault
+        public T? PatternOrDefault
         {
             get
             {
-                TryGetPattern(out T pattern);
+                TryGetPattern(out var pattern);
                 return pattern;
             }
         }
 
         /// <inheritdoc />
-        public bool TryGetPattern(out T pattern)
+        public bool TryGetPattern([NotNullWhen(true)] out T? pattern)
         {
-            if (FrameworkAutomationElement.TryGetNativePattern(_patternId, out TNative nativePattern))
+            if (FrameworkAutomationElement.TryGetNativePattern(_patternId, out TNative? nativePattern))
             {
                 pattern = _patternCreateFunc(FrameworkAutomationElement, nativePattern);
                 return true;

--- a/src/FlaUI.Core/AutomationProperty.cs
+++ b/src/FlaUI.Core/AutomationProperty.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using FlaUI.Core.Identifiers;
 
 namespace FlaUI.Core
 {
     /// <summary>
-    /// Inferface for property objects.
+    /// Interface for property objects.
     /// </summary>
     /// <typeparam name="T">The type of the value of the property.</typeparam>
     public interface IAutomationProperty<T>
@@ -19,7 +21,7 @@ namespace FlaUI.Core
         /// Gets the value of the property or the default for this property type if it is not supported.
         /// Throws if the property is accessed in a caching context and it is not cached.
         /// </summary>
-        T ValueOrDefault { get; }
+        T? ValueOrDefault { get; }
 
         /// <summary>
         /// Tries to get the value of the property.
@@ -27,7 +29,7 @@ namespace FlaUI.Core
         /// </summary>
         /// <param name="value">The value of the property. Contains the default if it is not supported.</param>
         /// <returns>True if the property is supported, false otherwise.</returns>
-        bool TryGetValue(out T value);
+        bool TryGetValue([NotNullWhen(true)] out T? value);
 
         /// <summary>
         /// Gets a flag if the property is supported or not.
@@ -66,17 +68,17 @@ namespace FlaUI.Core
         public TVal Value => FrameworkAutomationElement.GetPropertyValue<TVal>(PropertyId);
 
         /// <inheritdoc />
-        public TVal ValueOrDefault
+        public TVal? ValueOrDefault
         {
             get
             {
-                TryGetValue(out TVal value);
+                TryGetValue(out var value);
                 return value;
             }
         }
 
         /// <inheritdoc />
-        public bool TryGetValue(out TVal value)
+        public bool TryGetValue([NotNullWhen(true)] out TVal? value)
         {
             return FrameworkAutomationElement.TryGetPropertyValue(PropertyId, out value);
         }
@@ -88,7 +90,8 @@ namespace FlaUI.Core
         /// Implicit operator to convert the property object directly to its value.
         /// </summary>
         /// <param name="automationProperty">The property object which should be converted.</param>
-        public static implicit operator TVal(AutomationProperty<TVal> automationProperty)
+        [return: NotNullIfNotNull(nameof(automationProperty))]
+        public static implicit operator TVal?(AutomationProperty<TVal>? automationProperty)
         {
             return automationProperty == null ? default(TVal) : automationProperty.Value;
         }
@@ -98,9 +101,9 @@ namespace FlaUI.Core
         /// </summary>
         /// <param name="other">The other value.</param>
         /// <returns>True if they equal, false otherwise.</returns>
-        public bool Equals(TVal other)
+        public bool Equals(TVal? other)
         {
-            return Value.Equals(other);
+            return EqualityComparer<TVal>.Default.Equals(Value, other);
         }
 
         /// <summary>
@@ -108,9 +111,9 @@ namespace FlaUI.Core
         /// </summary>
         /// <param name="other">The other property.</param>
         /// <returns>True if they are value-equal, false otherwise.</returns>
-        public bool Equals(AutomationProperty<TVal> other)
+        public bool Equals(AutomationProperty<TVal>? other)
         {
-            return other != null && Value.Equals(other.Value);
+            return other != null && EqualityComparer<TVal>.Default.Equals(Value, other.Value);
         }
 
         /// <summary>

--- a/src/FlaUI.Core/CacheRequest.cs
+++ b/src/FlaUI.Core/CacheRequest.cs
@@ -65,9 +65,9 @@ namespace FlaUI.Core
     public partial class CacheRequest
     {
         [ThreadStatic]
-        private static Stack<CacheRequest> _cacheStack;
+        private static Stack<CacheRequest>? _cacheStack;
         [ThreadStatic]
-        private static Stack<bool> _forceNoCacheStack;
+        private static Stack<bool>? _forceNoCacheStack;
 
         /// <summary>
         /// Checks if a caching is currently active in the current context.
@@ -77,7 +77,7 @@ namespace FlaUI.Core
         /// <summary>
         /// Gets the current cache request object.
         /// </summary>
-        public static CacheRequest Current
+        public static CacheRequest? Current
         {
             get
             {
@@ -139,7 +139,7 @@ namespace FlaUI.Core
 
             public void Dispose()
             {
-                _forceNoCacheStack.Pop();
+                _forceNoCacheStack!.Pop();
             }
         }
     }

--- a/src/FlaUI.Core/Capturing/Capture.cs
+++ b/src/FlaUI.Core/Capturing/Capture.cs
@@ -17,7 +17,7 @@ namespace FlaUI.Core.Capturing
         /// <summary>
         /// Captures the main (primary) screen.
         /// </summary>
-        public static CaptureImage MainScreen(CaptureSettings settings = null)
+        public static CaptureImage MainScreen(CaptureSettings? settings = null)
         {
             var primaryScreenBounds = new Rectangle(
                 0, 0,
@@ -28,7 +28,7 @@ namespace FlaUI.Core.Capturing
         /// <summary>
         /// Captures the whole screen (all monitors).
         /// </summary>
-        public static CaptureImage Screen(int screenIndex = -1, CaptureSettings settings = null)
+        public static CaptureImage Screen(int screenIndex = -1, CaptureSettings? settings = null)
         {
             Rectangle capturingRectangle;
             // Take the appropriate screen if requested
@@ -50,7 +50,7 @@ namespace FlaUI.Core.Capturing
         /// <summary>
         /// Captures all screens an element is on.
         /// </summary>
-        public static CaptureImage ScreensWithElement(AutomationElement element, CaptureSettings settings = null)
+        public static CaptureImage ScreensWithElement(AutomationElement element, CaptureSettings? settings = null)
         {
             var elementRectangle = element.BoundingRectangle;
             var intersectedScreenBounds = new List<Rectangle>();
@@ -79,7 +79,7 @@ namespace FlaUI.Core.Capturing
         /// <summary>
         /// Captures an element and returns the image.
         /// </summary>
-        public static CaptureImage Element(AutomationElement element, CaptureSettings settings = null)
+        public static CaptureImage Element(AutomationElement element, CaptureSettings? settings = null)
         {
             return Rectangle(element.BoundingRectangle, settings);
         }
@@ -87,7 +87,7 @@ namespace FlaUI.Core.Capturing
         /// <summary>
         /// Captures a rectangle inside an element and returns the image.
         /// </summary>
-        public static CaptureImage ElementRectangle(AutomationElement element, Rectangle rectangle, CaptureSettings settings = null)
+        public static CaptureImage ElementRectangle(AutomationElement element, Rectangle rectangle, CaptureSettings? settings = null)
         {
             var elementBounds = element.BoundingRectangle;
             // Calculate the rectangle that should be captured
@@ -103,7 +103,7 @@ namespace FlaUI.Core.Capturing
         /// <summary>
         /// Captures a specific area from the screen.
         /// </summary>
-        public static CaptureImage Rectangle(Rectangle bounds, CaptureSettings settings = null)
+        public static CaptureImage Rectangle(Rectangle bounds, CaptureSettings? settings = null)
         {
             // Calculate the size of the output rectangle
             var outputRectangle = CaptureUtilities.ScaleAccordingToSettings(bounds, settings);

--- a/src/FlaUI.Core/Capturing/CaptureUtilities.cs
+++ b/src/FlaUI.Core/Capturing/CaptureUtilities.cs
@@ -76,7 +76,7 @@ namespace FlaUI.Core.Capturing
         /// <param name="originalBounds">The original bounds of the captured image.</param>
         /// <param name="captureSettings">The settings to use for the capture.</param>
         /// <returns>The transformed rectangle.</returns>
-        public static Rectangle ScaleAccordingToSettings(Rectangle originalBounds, CaptureSettings captureSettings)
+        public static Rectangle ScaleAccordingToSettings(Rectangle originalBounds, CaptureSettings? captureSettings)
         {
             // Default is the original size
             var outputWidth = originalBounds.Width;
@@ -111,7 +111,7 @@ namespace FlaUI.Core.Capturing
         /// <summary>
         /// Captures the cursor as bitmap and returns the bitmap and the position on screen of the cursor.
         /// </summary>
-        public static Bitmap CaptureCursor(ref Point position)
+        public static Bitmap? CaptureCursor(ref Point position)
         {
             var cursorInfo = new CURSORINFO();
             cursorInfo.cbSize = Marshal.SizeOf(cursorInfo);

--- a/src/FlaUI.Core/Capturing/VideoRecorder.cs
+++ b/src/FlaUI.Core/Capturing/VideoRecorder.cs
@@ -22,9 +22,9 @@ namespace FlaUI.Core.Capturing
         private readonly VideoRecorderSettings _settings;
         private readonly Func<VideoRecorder, CaptureImage> _captureMethod;
         private readonly BlockingCollection<ImageData> _frames;
-        private Task _recordTask;
+        private Task? _recordTask;
         private bool _shouldRecord;
-        private Task _writeTask;
+        private Task? _writeTask;
         private DateTime _recordStartTime;
         private static readonly HttpClient _httpClient = new HttpClient();
 
@@ -107,10 +107,10 @@ namespace FlaUI.Core.Capturing
             var videoPipeName = $"flaui-capture-{Guid.NewGuid()}";
             var ffmpegIn = new NamedPipeServerStream(videoPipeName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, 10000, 10000);
             const string pipePrefix = @"\\.\pipe\";
-            Process ffmpegProcess = null;
+            Process? ffmpegProcess = null;
 
             var isFirstFrame = true;
-            ImageData lastImage = null;
+            ImageData? lastImage = null;
             while (!_frames.IsCompleted)
             {
                 _frames.TryTake(out var img, -1);
@@ -280,7 +280,7 @@ namespace FlaUI.Core.Capturing
             public int Width { get; set; }
             public int Height { get; set; }
             public bool IsRepeatFrame { get; private set; }
-            public byte[] Data { get; set; }
+            public byte[]? Data { get; set; }
 
             public static readonly ImageData RepeatImage = new ImageData { IsRepeatFrame = true };
 

--- a/src/FlaUI.Core/Capturing/VideoRecorderSettings.cs
+++ b/src/FlaUI.Core/Capturing/VideoRecorderSettings.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The path to ffmpeg.exe.
         /// </summary>
-        public string ffmpegPath { get; set; }
+        public string? ffmpegPath { get; set; }
 
         /// <summary>
         /// The framerate used for capturing and playback.
@@ -19,7 +19,7 @@
         /// <summary>
         /// The path to the target video file.
         /// </summary>
-        public string TargetVideoPath { get; set; }
+        public string? TargetVideoPath { get; set; }
 
         /// <summary>
         /// Flag to indicate if compressed images should be captured.<para />

--- a/src/FlaUI.Core/CodeAnalysisAttributes.cs
+++ b/src/FlaUI.Core/CodeAnalysisAttributes.cs
@@ -1,0 +1,27 @@
+﻿#if NETFRAMEWORK || NETSTANDARD2_0
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        public bool ReturnValue { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = true)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        public string ParameterName { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute
+    {
+    }
+}
+
+#endif

--- a/src/FlaUI.Core/Debug.cs
+++ b/src/FlaUI.Core/Debug.cs
@@ -16,13 +16,13 @@ namespace FlaUI.Core
         /// Gets the XPath to the element until the desktop or the given root element.
         /// Warning: This is quite a heavy operation
         /// </summary>
-        public static string GetXPathToElement(AutomationElement element, AutomationElement rootElement = null)
+        public static string GetXPathToElement(AutomationElement element, AutomationElement? rootElement = null)
         {
             var treeWalker = element.Automation.TreeWalkerFactory.GetControlViewWalker();
             return GetXPathToElement(element, treeWalker, rootElement);
         }
 
-        private static string GetXPathToElement(AutomationElement element, ITreeWalker treeWalker, AutomationElement rootElement = null)
+        private static string GetXPathToElement(AutomationElement element, ITreeWalker treeWalker, AutomationElement? rootElement = null)
         {
             var parent = treeWalker.GetParent(element);
             if (parent == null || (rootElement != null && parent.Equals(rootElement)))
@@ -95,7 +95,7 @@ namespace FlaUI.Core
                 using (cr.Activate())
                 {
                     // Re-find the root element with caching activated
-                    automationElement = automationElement.FindFirst(TreeScope.Element, TrueCondition.Default);
+                    automationElement = automationElement.FindFirst(TreeScope.Element, TrueCondition.Default)!;
                     Details(stringBuilder, automationElement, String.Empty);
                 }
                 return stringBuilder.ToString();

--- a/src/FlaUI.Core/Definitions/FrameworkIds.cs
+++ b/src/FlaUI.Core/Definitions/FrameworkIds.cs
@@ -38,7 +38,7 @@ namespace FlaUI.Core.Definitions
         /// </summary>
         /// <param name="frameworkType">The <see cref="FrameworkType"/> to convert.</param>
         /// <returns>The matched string.</returns>
-        public static string Convert(FrameworkType frameworkType)
+        public static string? Convert(FrameworkType frameworkType)
         {
             if (TypeMapping.TryGetValue(frameworkType, out var frameworkId))
             {

--- a/src/FlaUI.Core/FlaUI.Core.csproj
+++ b/src/FlaUI.Core/FlaUI.Core.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net48;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/src/FlaUI.Core/FrameworkAutomationElementBase.Patterns.cs
+++ b/src/FlaUI.Core/FrameworkAutomationElementBase.Patterns.cs
@@ -4,40 +4,40 @@ namespace FlaUI.Core
 {
     public abstract partial class FrameworkAutomationElementBase : FrameworkAutomationElementBase.IFrameworkPatterns
     {
-        private IAutomationPattern<IAnnotationPattern> _annotationPattern;
-        private IAutomationPattern<IDockPattern> _dockPattern;
-        private IAutomationPattern<IDragPattern> _dragPattern;
-        private IAutomationPattern<IDropTargetPattern> _dropTargetPattern;
-        private IAutomationPattern<IExpandCollapsePattern> _expandCollapsePattern;
-        private IAutomationPattern<IGridItemPattern> _gridItemPattern;
-        private IAutomationPattern<IGridPattern> _gridPattern;
-        private IAutomationPattern<IInvokePattern> _invokePattern;
-        private IAutomationPattern<IItemContainerPattern> _itemContainerPattern;
-        private IAutomationPattern<ILegacyIAccessiblePattern> _legacyIAccessiblePattern;
-        private IAutomationPattern<IMultipleViewPattern> _multipleViewPattern;
-        private IAutomationPattern<IObjectModelPattern> _objectModelPattern;
-        private IAutomationPattern<IRangeValuePattern> _rangeValuePattern;
-        private IAutomationPattern<IScrollItemPattern> _scrollItemPattern;
-        private IAutomationPattern<IScrollPattern> _scrollPattern;
-        private IAutomationPattern<ISelectionItemPattern> _selectionItemPattern;
-        private IAutomationPattern<ISelection2Pattern> _selection2Pattern;
-        private IAutomationPattern<ISelectionPattern> _selectionPattern;
-        private IAutomationPattern<ISpreadsheetItemPattern> _spreadsheetItemPattern;
-        private IAutomationPattern<ISpreadsheetPattern> _spreadsheetPattern;
-        private IAutomationPattern<IStylesPattern> _stylesPattern;
-        private IAutomationPattern<ISynchronizedInputPattern> _synchronizedInputPattern;
-        private IAutomationPattern<ITableItemPattern> _tableItemPattern;
-        private IAutomationPattern<ITablePattern> _tablePattern;
-        private IAutomationPattern<ITextChildPattern> _textChildPattern;
-        private IAutomationPattern<ITextEditPattern> _textEditPattern;
-        private IAutomationPattern<IText2Pattern> _text2Pattern;
-        private IAutomationPattern<ITextPattern> _textPattern;
-        private IAutomationPattern<ITogglePattern> _togglePattern;
-        private IAutomationPattern<ITransform2Pattern> _transform2Pattern;
-        private IAutomationPattern<ITransformPattern> _transformPattern;
-        private IAutomationPattern<IValuePattern> _valuePattern;
-        private IAutomationPattern<IVirtualizedItemPattern> _virtualizedItemPattern;
-        private IAutomationPattern<IWindowPattern> _windowPattern;
+        private IAutomationPattern<IAnnotationPattern>? _annotationPattern;
+        private IAutomationPattern<IDockPattern>? _dockPattern;
+        private IAutomationPattern<IDragPattern>? _dragPattern;
+        private IAutomationPattern<IDropTargetPattern>? _dropTargetPattern;
+        private IAutomationPattern<IExpandCollapsePattern>? _expandCollapsePattern;
+        private IAutomationPattern<IGridItemPattern>? _gridItemPattern;
+        private IAutomationPattern<IGridPattern>? _gridPattern;
+        private IAutomationPattern<IInvokePattern>? _invokePattern;
+        private IAutomationPattern<IItemContainerPattern>? _itemContainerPattern;
+        private IAutomationPattern<ILegacyIAccessiblePattern>? _legacyIAccessiblePattern;
+        private IAutomationPattern<IMultipleViewPattern>? _multipleViewPattern;
+        private IAutomationPattern<IObjectModelPattern>? _objectModelPattern;
+        private IAutomationPattern<IRangeValuePattern>? _rangeValuePattern;
+        private IAutomationPattern<IScrollItemPattern>? _scrollItemPattern;
+        private IAutomationPattern<IScrollPattern>? _scrollPattern;
+        private IAutomationPattern<ISelectionItemPattern>? _selectionItemPattern;
+        private IAutomationPattern<ISelection2Pattern>? _selection2Pattern;
+        private IAutomationPattern<ISelectionPattern>? _selectionPattern;
+        private IAutomationPattern<ISpreadsheetItemPattern>? _spreadsheetItemPattern;
+        private IAutomationPattern<ISpreadsheetPattern>? _spreadsheetPattern;
+        private IAutomationPattern<IStylesPattern>? _stylesPattern;
+        private IAutomationPattern<ISynchronizedInputPattern>? _synchronizedInputPattern;
+        private IAutomationPattern<ITableItemPattern>? _tableItemPattern;
+        private IAutomationPattern<ITablePattern>? _tablePattern;
+        private IAutomationPattern<ITextChildPattern>? _textChildPattern;
+        private IAutomationPattern<ITextEditPattern>? _textEditPattern;
+        private IAutomationPattern<IText2Pattern>? _text2Pattern;
+        private IAutomationPattern<ITextPattern>? _textPattern;
+        private IAutomationPattern<ITogglePattern>? _togglePattern;
+        private IAutomationPattern<ITransform2Pattern>? _transform2Pattern;
+        private IAutomationPattern<ITransformPattern>? _transformPattern;
+        private IAutomationPattern<IValuePattern>? _valuePattern;
+        private IAutomationPattern<IVirtualizedItemPattern>? _virtualizedItemPattern;
+        private IAutomationPattern<IWindowPattern>? _windowPattern;
 
         /// <summary>
         /// Provides access to all patterns.

--- a/src/FlaUI.Core/FrameworkAutomationElementBase.Properties.cs
+++ b/src/FlaUI.Core/FrameworkAutomationElementBase.Properties.cs
@@ -9,62 +9,62 @@ namespace FlaUI.Core
 {
     public abstract partial class FrameworkAutomationElementBase : FrameworkAutomationElementBase.IProperties
     {
-        private AutomationProperty<string> _acceleratorKey;
-        private AutomationProperty<string> _accessKey;
-        private AutomationProperty<int[]> _annotationObjects;
-        private AutomationProperty<int[]> _annotationTypes;
-        private AutomationProperty<string> _ariaProperties;
-        private AutomationProperty<string> _ariaRole;
-        private AutomationProperty<string> _automationId;
-        private AutomationProperty<Rectangle> _boundingRectangle;
-        private AutomationProperty<Point> _centerPoint;
-        private AutomationProperty<string> _className;
-        private AutomationProperty<Point> _clickablePoint;
-        private AutomationProperty<AutomationElement[]> _controllerFor;
-        private AutomationProperty<ControlType> _controlType;
-        private AutomationProperty<CultureInfo> _culture;
-        private AutomationProperty<AutomationElement[]> _describedBy;
-        private AutomationProperty<int> _fillColor;
-        private AutomationProperty<int> _fillType;
-        private AutomationProperty<AutomationElement[]> _flowsFrom;
-        private AutomationProperty<AutomationElement[]> _flowsTo;
-        private AutomationProperty<string> _frameworkId;
-        private AutomationProperty<string> _fullDescription;
-        private AutomationProperty<bool> _hasKeyboardFocus;
-        private AutomationProperty<HeadingLevel> _headingLevel;
-        private AutomationProperty<string> _helpText;
-        private AutomationProperty<bool> _isContentElement;
-        private AutomationProperty<bool> _isControlElement;
-        private AutomationProperty<bool> _isDataValidForForm;
-        private AutomationProperty<bool> _isDialog;
-        private AutomationProperty<bool> _isEnabled;
-        private AutomationProperty<bool> _isKeyboardFocusable;
-        private AutomationProperty<bool> _isOffscreen;
-        private AutomationProperty<bool> _isPassword;
-        private AutomationProperty<bool> _isPeripheral;
-        private AutomationProperty<bool> _isRequiredForForm;
-        private AutomationProperty<string> _itemStatus;
-        private AutomationProperty<string> _itemType;
-        private AutomationProperty<AutomationElement> _labeledBy;
-        private AutomationProperty<LandmarkType> _landmarkType;
-        private AutomationProperty<int> _level;
-        private AutomationProperty<LiveSetting> _liveSetting;
-        private AutomationProperty<string> _localizedControlType;
-        private AutomationProperty<string> _localizedLandmarkType;
-        private AutomationProperty<string> _name;
-        private AutomationProperty<IntPtr> _nativeWindowHandle;
-        private AutomationProperty<bool> _optimizeForVisualContent;
-        private AutomationProperty<OrientationType> _orientation;
-        private AutomationProperty<int[]> _outlineColor;
-        private AutomationProperty<int[]> _outlineThickness;
-        private AutomationProperty<int> _positionInSet;
-        private AutomationProperty<int> _processId;
-        private AutomationProperty<string> _providerDescription;
-        private AutomationProperty<int> _rotation;
-        private AutomationProperty<int[]> _runtimeId;
-        private AutomationProperty<int[]> _size;
-        private AutomationProperty<int> _sizeOfSet;
-        private AutomationProperty<VisualEffects> _visualEffects;
+        private AutomationProperty<string>? _acceleratorKey;
+        private AutomationProperty<string>? _accessKey;
+        private AutomationProperty<int[]>? _annotationObjects;
+        private AutomationProperty<int[]>? _annotationTypes;
+        private AutomationProperty<string>? _ariaProperties;
+        private AutomationProperty<string>? _ariaRole;
+        private AutomationProperty<string>? _automationId;
+        private AutomationProperty<Rectangle>? _boundingRectangle;
+        private AutomationProperty<Point>? _centerPoint;
+        private AutomationProperty<string>? _className;
+        private AutomationProperty<Point>? _clickablePoint;
+        private AutomationProperty<AutomationElement[]>? _controllerFor;
+        private AutomationProperty<ControlType>? _controlType;
+        private AutomationProperty<CultureInfo>? _culture;
+        private AutomationProperty<AutomationElement[]>? _describedBy;
+        private AutomationProperty<int>? _fillColor;
+        private AutomationProperty<int>? _fillType;
+        private AutomationProperty<AutomationElement[]>? _flowsFrom;
+        private AutomationProperty<AutomationElement[]>? _flowsTo;
+        private AutomationProperty<string>? _frameworkId;
+        private AutomationProperty<string>? _fullDescription;
+        private AutomationProperty<bool>? _hasKeyboardFocus;
+        private AutomationProperty<HeadingLevel>? _headingLevel;
+        private AutomationProperty<string>? _helpText;
+        private AutomationProperty<bool>? _isContentElement;
+        private AutomationProperty<bool>? _isControlElement;
+        private AutomationProperty<bool>? _isDataValidForForm;
+        private AutomationProperty<bool>? _isDialog;
+        private AutomationProperty<bool>? _isEnabled;
+        private AutomationProperty<bool>? _isKeyboardFocusable;
+        private AutomationProperty<bool>? _isOffscreen;
+        private AutomationProperty<bool>? _isPassword;
+        private AutomationProperty<bool>? _isPeripheral;
+        private AutomationProperty<bool>? _isRequiredForForm;
+        private AutomationProperty<string>? _itemStatus;
+        private AutomationProperty<string>? _itemType;
+        private AutomationProperty<AutomationElement>? _labeledBy;
+        private AutomationProperty<LandmarkType>? _landmarkType;
+        private AutomationProperty<int>? _level;
+        private AutomationProperty<LiveSetting>? _liveSetting;
+        private AutomationProperty<string>? _localizedControlType;
+        private AutomationProperty<string>? _localizedLandmarkType;
+        private AutomationProperty<string>? _name;
+        private AutomationProperty<IntPtr>? _nativeWindowHandle;
+        private AutomationProperty<bool>? _optimizeForVisualContent;
+        private AutomationProperty<OrientationType>? _orientation;
+        private AutomationProperty<int[]>? _outlineColor;
+        private AutomationProperty<int[]>? _outlineThickness;
+        private AutomationProperty<int>? _positionInSet;
+        private AutomationProperty<int>? _processId;
+        private AutomationProperty<string>? _providerDescription;
+        private AutomationProperty<int>? _rotation;
+        private AutomationProperty<int[]>? _runtimeId;
+        private AutomationProperty<int[]>? _size;
+        private AutomationProperty<int>? _sizeOfSet;
+        private AutomationProperty<VisualEffects>? _visualEffects;
 
         /// <summary>
         /// Provides access to all properties.
@@ -313,7 +313,7 @@ namespace FlaUI.Core
 
         public AutomationProperty<VisualEffects> VisualEffects => GetOrCreate(ref _visualEffects, PropertyIdLibrary.VisualEffects);
 
-        private AutomationProperty<T> GetOrCreate<T>(ref AutomationProperty<T> val, PropertyId propertyId)
+        private AutomationProperty<T> GetOrCreate<T>(ref AutomationProperty<T>? val, PropertyId propertyId)
         {
             return val ?? (val = new AutomationProperty<T>(propertyId, this));
         }

--- a/src/FlaUI.Core/FrameworkAutomationElementBase.cs
+++ b/src/FlaUI.Core/FrameworkAutomationElementBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.AutomationElements.Infrastructure;
@@ -87,7 +88,7 @@ namespace FlaUI.Core
         /// <param name="property">The <see cref="PropertyId"/> of the property to get the value from.</param>
         /// <param name="value">The out object where the value should be put. Is the default if the property is not supported.</param>
         /// <returns>True if the property is supported and false otherwise.</returns>
-        public bool TryGetPropertyValue(PropertyId property, out object value)
+        public bool TryGetPropertyValue(PropertyId property, [NotNullWhen(true)] out object? value)
         {
             return TryGetPropertyValue<object>(property, out value);
         }
@@ -99,7 +100,7 @@ namespace FlaUI.Core
         /// <param name="property">The <see cref="PropertyId"/> of the property to get the value from.</param>
         /// <param name="value">The out object where the value should be put. Is the default if the property is not supported.</param>
         /// <returns>True if the property is supported and false otherwise.</returns>
-        public bool TryGetPropertyValue<T>(PropertyId property, out T value)
+        public bool TryGetPropertyValue<T>(PropertyId property, [NotNullWhen(true)] out T? value)
         {
             if (Equals(property, PropertyId.NotSupportedByFramework))
             {
@@ -175,7 +176,7 @@ namespace FlaUI.Core
         /// <param name="pattern">The <see cref="PatternId"/> of the pattern to get.</param>
         /// <param name="nativePattern">The out object where the pattern should be put. Is null if the pattern is not supported.</param>
         /// <returns>True if the pattern is supported and false otherwise.</returns>
-        public bool TryGetNativePattern<T>(PatternId pattern, out T nativePattern)
+        public bool TryGetNativePattern<T>(PatternId pattern, [NotNullWhen(true)] out T? nativePattern)
         {
             try
             {
@@ -228,16 +229,16 @@ namespace FlaUI.Core
         public abstract AutomationElement[] FindAll(TreeScope treeScope, ConditionBase condition);
 
         /// <inheritdoc />
-        public abstract AutomationElement FindFirst(TreeScope treeScope, ConditionBase condition);
+        public abstract AutomationElement? FindFirst(TreeScope treeScope, ConditionBase condition);
 
         /// <inheritdoc />
         public abstract AutomationElement[] FindAllWithOptions(TreeScope treeScope, ConditionBase condition, TreeTraversalOptions traversalOptions, AutomationElement root);
 
         /// <inheritdoc />
-        public abstract AutomationElement FindFirstWithOptions(TreeScope treeScope, ConditionBase condition, TreeTraversalOptions traversalOptions, AutomationElement root);
+        public abstract AutomationElement? FindFirstWithOptions(TreeScope treeScope, ConditionBase condition, TreeTraversalOptions traversalOptions, AutomationElement root);
 
         /// <inheritdoc />
-        public abstract AutomationElement FindAt(TreeScope treeScope, int index, ConditionBase condition);
+        public abstract AutomationElement? FindAt(TreeScope treeScope, int index, ConditionBase condition);
 
         /// <summary>
         /// Tries to get a clickable point.
@@ -282,7 +283,7 @@ namespace FlaUI.Core
 
         public abstract PatternId[] GetSupportedPatterns();
         public abstract PropertyId[] GetSupportedProperties();
-        public abstract AutomationElement GetUpdatedCache();
+        public abstract AutomationElement? GetUpdatedCache();
         public abstract AutomationElement[] GetCachedChildren();
         public abstract AutomationElement GetCachedParent();
         public abstract object GetCurrentMetadataValue(PropertyId targetId, int metadataId);

--- a/src/FlaUI.Core/Identifiers/ConvertibleIdentifierBase.cs
+++ b/src/FlaUI.Core/Identifiers/ConvertibleIdentifierBase.cs
@@ -7,7 +7,7 @@ namespace FlaUI.Core.Identifiers
     /// </summary>
     public abstract class ConvertibleIdentifierBase : IdentifierBase
     {
-        private Func<AutomationBase, object, object> _converterMethod;
+        private Func<AutomationBase, object, object>? _converterMethod;
 
         protected ConvertibleIdentifierBase(int id, string name)
             : base(id, name)

--- a/src/FlaUI.Core/Identifiers/IdentifierBase.cs
+++ b/src/FlaUI.Core/Identifiers/IdentifierBase.cs
@@ -56,12 +56,12 @@ namespace FlaUI.Core.Identifiers
             Name = name;
         }
 
-        public bool Equals(IdentifierBase other)
+        public bool Equals(IdentifierBase? other)
         {
             return other != null && Id.Equals(other.Id);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as IdentifierBase);
         }

--- a/src/FlaUI.Core/Identifiers/PatternId.cs
+++ b/src/FlaUI.Core/Identifiers/PatternId.cs
@@ -10,7 +10,7 @@
         /// </summary>
         public static readonly PatternId NotSupportedByFramework = new PatternId(-1, "Not supported", null);
 
-        public PatternId(int id, string name, PropertyId availabilityProperty)
+        public PatternId(int id, string name, PropertyId? availabilityProperty)
             : base(id, name)
         {
             AvailabilityProperty = availabilityProperty;
@@ -19,7 +19,7 @@
         /// <summary>
         /// Property which can be used to check for the patterns availability on an element
         /// </summary>
-        public PropertyId AvailabilityProperty { get; private set; }
+        public PropertyId? AvailabilityProperty { get; private set; }
 
         public static PatternId Register(AutomationType automationType, int id, string name, PropertyId availabilityProperty)
         {

--- a/src/FlaUI.Core/Logging/EventLogger.cs
+++ b/src/FlaUI.Core/Logging/EventLogger.cs
@@ -4,13 +4,13 @@ namespace FlaUI.Core.Logging
 {
     public class EventLogger : LoggerBase
     {
-        public event Action<string> OnTrace;
-        public event Action<string> OnDebug;
-        public event Action<string> OnInfo;
-        public event Action<string> OnWarn;
-        public event Action<string> OnError;
-        public event Action<string> OnFatal;
-        public event Action<LogLevel, string> OnLog;
+        public event Action<string>? OnTrace;
+        public event Action<string>? OnDebug;
+        public event Action<string>? OnInfo;
+        public event Action<string>? OnWarn;
+        public event Action<string>? OnError;
+        public event Action<string>? OnFatal;
+        public event Action<LogLevel, string>? OnLog;
 
         protected override void GatedTrace(string message)
         {

--- a/src/FlaUI.Core/Logging/LoggerBase.cs
+++ b/src/FlaUI.Core/Logging/LoggerBase.cs
@@ -46,7 +46,7 @@ namespace FlaUI.Core.Logging
             Log(logLevel, message, null, args);
         }
 
-        public void Log(LogLevel logLevel, string message, Exception exception, params object[] args)
+        public void Log(LogLevel logLevel, string message, Exception? exception, params object[] args)
         {
             switch (logLevel)
             {
@@ -133,7 +133,7 @@ namespace FlaUI.Core.Logging
             Log(LogLevel.Fatal, message, exception, args);
         }
 
-        private string GetFormattedMessage(string message, Exception exception, params object[] args)
+        private string GetFormattedMessage(string? message, Exception? exception, params object[]? args)
         {
             var messageParts = new List<string>();
             if (message != null)

--- a/src/FlaUI.Core/Patterns/AnnotationPattern.cs
+++ b/src/FlaUI.Core/Patterns/AnnotationPattern.cs
@@ -28,11 +28,11 @@ namespace FlaUI.Core.Patterns
     public abstract class AnnotationPatternBase<TNativePattern> : PatternBase<TNativePattern>, IAnnotationPattern
         where TNativePattern : class
     {
-        private AutomationProperty<AnnotationType> _annotationType;
-        private AutomationProperty<string> _annotationTypeName;
-        private AutomationProperty<string> _author;
-        private AutomationProperty<string> _dateTime;
-        private AutomationProperty<AutomationElement> _target;
+        private AutomationProperty<AnnotationType>? _annotationType;
+        private AutomationProperty<string>? _annotationTypeName;
+        private AutomationProperty<string>? _author;
+        private AutomationProperty<string>? _dateTime;
+        private AutomationProperty<AutomationElement>? _target;
 
         protected AnnotationPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/DockPattern.cs
+++ b/src/FlaUI.Core/Patterns/DockPattern.cs
@@ -21,7 +21,7 @@ namespace FlaUI.Core.Patterns
     public abstract class DockPatternBase<TNativePattern> : PatternBase<TNativePattern>, IDockPattern
         where TNativePattern : class
     {
-        private AutomationProperty<DockPosition> _dockPosition;
+        private AutomationProperty<DockPosition>? _dockPosition;
 
         protected DockPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/DragPattern.cs
+++ b/src/FlaUI.Core/Patterns/DragPattern.cs
@@ -33,10 +33,10 @@ namespace FlaUI.Core.Patterns
     public abstract class DragPatternBase<TNativePattern> : PatternBase<TNativePattern>, IDragPattern
         where TNativePattern : class
     {
-        private AutomationProperty<string> _dropEffect;
-        private AutomationProperty<string[]> _dropEffects;
-        private AutomationProperty<bool> _isGrabbed;
-        private AutomationProperty<AutomationElement[]> _grabbedItems;
+        private AutomationProperty<string>? _dropEffect;
+        private AutomationProperty<string[]>? _dropEffects;
+        private AutomationProperty<bool>? _isGrabbed;
+        private AutomationProperty<AutomationElement[]>? _grabbedItems;
 
         protected DragPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/DropTargetPattern.cs
+++ b/src/FlaUI.Core/Patterns/DropTargetPattern.cs
@@ -28,8 +28,8 @@ namespace FlaUI.Core.Patterns
     public abstract class DropTargetPatternBase<TNativePattern> : PatternBase<TNativePattern>, IDropTargetPattern
         where TNativePattern : class
     {
-        private AutomationProperty<string> _dropTargetEffect;
-        private AutomationProperty<string[]> _dropTargetEffects;
+        private AutomationProperty<string>? _dropTargetEffect;
+        private AutomationProperty<string[]>? _dropTargetEffects;
 
         protected DropTargetPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/ExpandCollapsePattern.cs
+++ b/src/FlaUI.Core/Patterns/ExpandCollapsePattern.cs
@@ -22,7 +22,7 @@ namespace FlaUI.Core.Patterns
     public abstract class ExpandCollapsePatternBase<TNativePattern> : PatternBase<TNativePattern>, IExpandCollapsePattern
         where TNativePattern : class
     {
-        private AutomationProperty<ExpandCollapseState> _expandCollapseState;
+        private AutomationProperty<ExpandCollapseState>? _expandCollapseState;
 
         protected ExpandCollapsePatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/GridItemPattern.cs
+++ b/src/FlaUI.Core/Patterns/GridItemPattern.cs
@@ -27,11 +27,11 @@ namespace FlaUI.Core.Patterns
     public abstract class GridItemPatternBase<TNativePattern> : PatternBase<TNativePattern>, IGridItemPattern
         where TNativePattern : class
     {
-        private AutomationProperty<int> _column;
-        private AutomationProperty<int> _columnSpan;
-        private AutomationProperty<AutomationElement> _containingGrid;
-        private AutomationProperty<int> _row;
-        private AutomationProperty<int> _rowSpan;
+        private AutomationProperty<int>? _column;
+        private AutomationProperty<int>? _columnSpan;
+        private AutomationProperty<AutomationElement>? _containingGrid;
+        private AutomationProperty<int>? _row;
+        private AutomationProperty<int>? _rowSpan;
 
         protected GridItemPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/GridPattern.cs
+++ b/src/FlaUI.Core/Patterns/GridPattern.cs
@@ -23,8 +23,8 @@ namespace FlaUI.Core.Patterns
     public abstract class GridPatternBase<TNativePattern> : PatternBase<TNativePattern>, IGridPattern
         where TNativePattern : class
     {
-        private AutomationProperty<int> _columnCount;
-        private AutomationProperty<int> _rowCount;
+        private AutomationProperty<int>? _columnCount;
+        private AutomationProperty<int>? _rowCount;
 
         protected GridPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/Infrastructure/PatternBase.cs
+++ b/src/FlaUI.Core/Patterns/Infrastructure/PatternBase.cs
@@ -22,7 +22,7 @@ namespace FlaUI.Core.Patterns.Infrastructure
 
         public AutomationBase Automation => FrameworkAutomationElement.Automation;
 
-        protected AutomationProperty<T> GetOrCreate<T>(ref AutomationProperty<T> val, PropertyId propertyId)
+        protected AutomationProperty<T> GetOrCreate<T>(ref AutomationProperty<T>? val, PropertyId propertyId)
         {
             return val ?? (val = new AutomationProperty<T>(propertyId, FrameworkAutomationElement));
         }

--- a/src/FlaUI.Core/Patterns/ItemContainerPattern.cs
+++ b/src/FlaUI.Core/Patterns/ItemContainerPattern.cs
@@ -6,6 +6,6 @@ namespace FlaUI.Core.Patterns
 {
     public interface IItemContainerPattern : IPattern
     {
-        AutomationElement FindItemByProperty(AutomationElement startAfter, PropertyId property, object value);
+        AutomationElement? FindItemByProperty(AutomationElement? startAfter, PropertyId? property, object? value);
     }
 }

--- a/src/FlaUI.Core/Patterns/LegacyIAccessiblePattern.cs
+++ b/src/FlaUI.Core/Patterns/LegacyIAccessiblePattern.cs
@@ -42,16 +42,16 @@ namespace FlaUI.Core.Patterns
     public abstract partial class LegacyIAccessiblePatternBase<TNativePattern> : PatternBase<TNativePattern>, ILegacyIAccessiblePattern
         where TNativePattern : class
     {
-        private AutomationProperty<int> _childId;
-        private AutomationProperty<string> _defaultAction;
-        private AutomationProperty<string> _description;
-        private AutomationProperty<string> _help;
-        private AutomationProperty<string> _keyboardShortcut;
-        private AutomationProperty<string> _name;
-        private AutomationProperty<AccessibilityRole> _role;
-        private AutomationProperty<AutomationElement[]> _selection;
-        private AutomationProperty<AccessibilityState> _state;
-        private AutomationProperty<string> _value;
+        private AutomationProperty<int>? _childId;
+        private AutomationProperty<string>? _defaultAction;
+        private AutomationProperty<string>? _description;
+        private AutomationProperty<string>? _help;
+        private AutomationProperty<string>? _keyboardShortcut;
+        private AutomationProperty<string>? _name;
+        private AutomationProperty<AccessibilityRole>? _role;
+        private AutomationProperty<AutomationElement[]>? _selection;
+        private AutomationProperty<AccessibilityState>? _state;
+        private AutomationProperty<string>? _value;
 
         protected LegacyIAccessiblePatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/MultipleViewPattern.cs
+++ b/src/FlaUI.Core/Patterns/MultipleViewPattern.cs
@@ -23,8 +23,8 @@ namespace FlaUI.Core.Patterns
     public abstract class MultipleViewPatternBase<TNativePattern> : PatternBase<TNativePattern>, IMultipleViewPattern
         where TNativePattern : class
     {
-        private AutomationProperty<int> _currentView;
-        private AutomationProperty<int[]> _supportedViews;
+        private AutomationProperty<int>? _currentView;
+        private AutomationProperty<int[]>? _supportedViews;
 
         protected MultipleViewPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/RangeValuePattern.cs
+++ b/src/FlaUI.Core/Patterns/RangeValuePattern.cs
@@ -30,12 +30,12 @@ namespace FlaUI.Core.Patterns
     public abstract class RangeValuePatternBase<TNativePattern> : PatternBase<TNativePattern>, IRangeValuePattern
         where TNativePattern : class
     {
-        private AutomationProperty<bool> _isReadOnly;
-        private AutomationProperty<double> _largeChange;
-        private AutomationProperty<double> _maximum;
-        private AutomationProperty<double> _minimum;
-        private AutomationProperty<double> _smallChange;
-        private AutomationProperty<double> _value;
+        private AutomationProperty<bool>? _isReadOnly;
+        private AutomationProperty<double>? _largeChange;
+        private AutomationProperty<double>? _maximum;
+        private AutomationProperty<double>? _minimum;
+        private AutomationProperty<double>? _smallChange;
+        private AutomationProperty<double>? _value;
 
         protected RangeValuePatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/ScrollPattern.cs
+++ b/src/FlaUI.Core/Patterns/ScrollPattern.cs
@@ -37,12 +37,12 @@ namespace FlaUI.Core.Patterns
     public abstract class ScrollPatternBase<TNativePattern> : PatternBase<TNativePattern>, IScrollPattern
         where TNativePattern : class
     {
-        private AutomationProperty<bool> _horizontallyScrollable;
-        private AutomationProperty<double> _horizontalScrollPercent;
-        private AutomationProperty<double> _horizontalViewSize;
-        private AutomationProperty<bool> _verticallyScrollable;
-        private AutomationProperty<double> _verticalScrollPercent;
-        private AutomationProperty<double> _verticalViewSize;
+        private AutomationProperty<bool>? _horizontallyScrollable;
+        private AutomationProperty<double>? _horizontalScrollPercent;
+        private AutomationProperty<double>? _horizontalViewSize;
+        private AutomationProperty<bool>? _verticallyScrollable;
+        private AutomationProperty<double>? _verticalScrollPercent;
+        private AutomationProperty<double>? _verticalViewSize;
 
         protected ScrollPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/Selection2Pattern.cs
+++ b/src/FlaUI.Core/Patterns/Selection2Pattern.cs
@@ -24,10 +24,10 @@ namespace FlaUI.Core.Patterns
     public abstract class Selection2PatternBase<TNativePattern> : SelectionPatternBase<TNativePattern>, ISelection2Pattern
         where TNativePattern : class
     {
-        private AutomationProperty<AutomationElement> _currentSelectedItem;
-        private AutomationProperty<AutomationElement> _firstSelectedItem;
-        private AutomationProperty<int> _itemCount;
-        private AutomationProperty<AutomationElement> _lastSelectedItem;
+        private AutomationProperty<AutomationElement>? _currentSelectedItem;
+        private AutomationProperty<AutomationElement>? _firstSelectedItem;
+        private AutomationProperty<int>? _itemCount;
+        private AutomationProperty<AutomationElement>? _lastSelectedItem;
 
         protected Selection2PatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/SelectionItemPattern.cs
+++ b/src/FlaUI.Core/Patterns/SelectionItemPattern.cs
@@ -33,8 +33,8 @@ namespace FlaUI.Core.Patterns
     public abstract class SelectionItemPatternBase<TNativePattern> : PatternBase<TNativePattern>, ISelectionItemPattern
         where TNativePattern : class
     {
-        private AutomationProperty<bool> _isSelected;
-        private AutomationProperty<AutomationElement> _selectionContainer;
+        private AutomationProperty<bool>? _isSelected;
+        private AutomationProperty<AutomationElement>? _selectionContainer;
 
         protected SelectionItemPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/SelectionPattern.cs
+++ b/src/FlaUI.Core/Patterns/SelectionPattern.cs
@@ -29,9 +29,9 @@ namespace FlaUI.Core.Patterns
     public abstract class SelectionPatternBase<TNativePattern> : PatternBase<TNativePattern>, ISelectionPattern
         where TNativePattern : class
     {
-        private AutomationProperty<bool> _canSelectMultiple;
-        private AutomationProperty<bool> _isSelectionRequired;
-        private AutomationProperty<AutomationElement[]> _selection;
+        private AutomationProperty<bool>? _canSelectMultiple;
+        private AutomationProperty<bool>? _isSelectionRequired;
+        private AutomationProperty<AutomationElement[]>? _selection;
 
         protected SelectionPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/SpreadsheetItemPattern.cs
+++ b/src/FlaUI.Core/Patterns/SpreadsheetItemPattern.cs
@@ -24,9 +24,9 @@ namespace FlaUI.Core.Patterns
     public abstract class SpreadsheetItemPatternBase<TNativePattern> : PatternBase<TNativePattern>, ISpreadsheetItemPattern
         where TNativePattern : class
     {
-        private AutomationProperty<string> _formula;
-        private AutomationProperty<AutomationElement[]> _annotationObjects;
-        private AutomationProperty<AnnotationType[]> _annotationTypes;
+        private AutomationProperty<string>? _formula;
+        private AutomationProperty<AutomationElement[]>? _annotationObjects;
+        private AutomationProperty<AnnotationType[]>? _annotationTypes;
 
         protected SpreadsheetItemPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/StylesPattern.cs
+++ b/src/FlaUI.Core/Patterns/StylesPattern.cs
@@ -31,13 +31,13 @@ namespace FlaUI.Core.Patterns
     public abstract class StylesPatternBase<TNativePattern> : PatternBase<TNativePattern>, IStylesPattern
         where TNativePattern : class
     {
-        private AutomationProperty<string> _extendedProperties;
-        private AutomationProperty<int> _fillColor;
-        private AutomationProperty<int> _fillPatternColor;
-        private AutomationProperty<string> _fillPatternStyle;
-        private AutomationProperty<string> _shape;
-        private AutomationProperty<StyleType> _style;
-        private AutomationProperty<string> _styleName;
+        private AutomationProperty<string>? _extendedProperties;
+        private AutomationProperty<int>? _fillColor;
+        private AutomationProperty<int>? _fillPatternColor;
+        private AutomationProperty<string>? _fillPatternStyle;
+        private AutomationProperty<string>? _shape;
+        private AutomationProperty<StyleType>? _style;
+        private AutomationProperty<string>? _styleName;
 
         protected StylesPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/TableItemPattern.cs
+++ b/src/FlaUI.Core/Patterns/TableItemPattern.cs
@@ -21,8 +21,8 @@ namespace FlaUI.Core.Patterns
     public abstract class TableItemPatternBase<TNativePattern> : PatternBase<TNativePattern>, ITableItemPattern
         where TNativePattern : class
     {
-        private AutomationProperty<AutomationElement[]> _columnHeaderItems;
-        private AutomationProperty<AutomationElement[]> _rowHeaderItems;
+        private AutomationProperty<AutomationElement[]>? _columnHeaderItems;
+        private AutomationProperty<AutomationElement[]>? _rowHeaderItems;
 
         protected TableItemPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/TablePattern.cs
+++ b/src/FlaUI.Core/Patterns/TablePattern.cs
@@ -24,9 +24,9 @@ namespace FlaUI.Core.Patterns
     public abstract class TablePatternBase<TNativePattern> : PatternBase<TNativePattern>, ITablePattern
         where TNativePattern : class
     {
-        private AutomationProperty<AutomationElement[]> _columnHeaders;
-        private AutomationProperty<AutomationElement[]> _rowHeaders;
-        private AutomationProperty<RowOrColumnMajor> _rowOrColumnMajor;
+        private AutomationProperty<AutomationElement[]>? _columnHeaders;
+        private AutomationProperty<AutomationElement[]>? _rowHeaders;
+        private AutomationProperty<RowOrColumnMajor>? _rowOrColumnMajor;
 
         protected TablePatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/TogglePattern.cs
+++ b/src/FlaUI.Core/Patterns/TogglePattern.cs
@@ -21,7 +21,7 @@ namespace FlaUI.Core.Patterns
     public abstract class TogglePatternBase<TNativePattern> : PatternBase<TNativePattern>, ITogglePattern
         where TNativePattern : class
     {
-        private AutomationProperty<ToggleState> _toggleState;
+        private AutomationProperty<ToggleState>? _toggleState;
 
         protected TogglePatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/Transform2Pattern.cs
+++ b/src/FlaUI.Core/Patterns/Transform2Pattern.cs
@@ -27,10 +27,10 @@ namespace FlaUI.Core.Patterns
     public abstract class Transform2PatternBase<TNativePattern> : TransformPatternBase<TNativePattern>, ITransform2Pattern
         where TNativePattern : class
     {
-        private AutomationProperty<bool> _canZoom;
-        private AutomationProperty<double> _zoomLevel;
-        private AutomationProperty<double> _zoomMaximum;
-        private AutomationProperty<double> _zoomMinimum;
+        private AutomationProperty<bool>? _canZoom;
+        private AutomationProperty<double>? _zoomLevel;
+        private AutomationProperty<double>? _zoomMaximum;
+        private AutomationProperty<double>? _zoomMinimum;
 
         protected Transform2PatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/TransformPattern.cs
+++ b/src/FlaUI.Core/Patterns/TransformPattern.cs
@@ -26,9 +26,9 @@ namespace FlaUI.Core.Patterns
     public abstract class TransformPatternBase<TNativePattern> : PatternBase<TNativePattern>, ITransformPattern
         where TNativePattern : class
     {
-        private AutomationProperty<bool> _canMove;
-        private AutomationProperty<bool> _canResize;
-        private AutomationProperty<bool> _canRotate;
+        private AutomationProperty<bool>? _canMove;
+        private AutomationProperty<bool>? _canResize;
+        private AutomationProperty<bool>? _canRotate;
 
         protected TransformPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/ValuePattern.cs
+++ b/src/FlaUI.Core/Patterns/ValuePattern.cs
@@ -36,8 +36,8 @@ namespace FlaUI.Core.Patterns
     public abstract class ValuePatternBase<TNativePattern> : PatternBase<TNativePattern>, IValuePattern
         where TNativePattern : class
     {
-        private AutomationProperty<bool> _isReadOnly;
-        private AutomationProperty<string> _value;
+        private AutomationProperty<bool>? _isReadOnly;
+        private AutomationProperty<string>? _value;
 
         protected ValuePatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Patterns/WindowPattern.cs
+++ b/src/FlaUI.Core/Patterns/WindowPattern.cs
@@ -40,12 +40,12 @@ namespace FlaUI.Core.Patterns
     public abstract class WindowPatternBase<TNativePattern> : PatternBase<TNativePattern>, IWindowPattern
         where TNativePattern : class
     {
-        private AutomationProperty<bool> _canMaximize;
-        private AutomationProperty<bool> _canMinimize;
-        private AutomationProperty<bool> _isModal;
-        private AutomationProperty<bool> _isTopmost;
-        private AutomationProperty<WindowInteractionState> _windowInteractionState;
-        private AutomationProperty<WindowVisualState> _windowVisualState;
+        private AutomationProperty<bool>? _canMaximize;
+        private AutomationProperty<bool>? _canMinimize;
+        private AutomationProperty<bool>? _isModal;
+        private AutomationProperty<bool>? _isTopmost;
+        private AutomationProperty<WindowInteractionState>? _windowInteractionState;
+        private AutomationProperty<WindowVisualState>? _windowVisualState;
 
         protected WindowPatternBase(FrameworkAutomationElementBase frameworkAutomationElement, TNativePattern nativePattern) : base(frameworkAutomationElement, nativePattern)
         {

--- a/src/FlaUI.Core/Tools/Com.cs
+++ b/src/FlaUI.Core/Tools/Com.cs
@@ -54,7 +54,7 @@ namespace FlaUI.Core.Tools
             }
             catch (COMException ex)
             {
-                if (ConvertException(ex, out Exception newEx))
+                if (ConvertException(ex, out var newEx))
                 {
                     throw newEx;
                 }
@@ -79,7 +79,7 @@ namespace FlaUI.Core.Tools
             }
             catch (COMException ex)
             {
-                if (ConvertException(ex, out Exception newEx))
+                if (ConvertException(ex, out var newEx))
                 {
                     throw newEx;
                 }
@@ -99,7 +99,7 @@ namespace FlaUI.Core.Tools
             }
             catch (COMException ex)
             {
-                if (ConvertException(ex, out Exception newEx))
+                if (ConvertException(ex, out var newEx))
                 {
                     throw newEx;
                 }
@@ -111,7 +111,7 @@ namespace FlaUI.Core.Tools
         /// <summary>
         /// Tries to convert a com exception to a more usable exception.
         /// </summary>
-        public static bool ConvertException(COMException ex, out Exception uiaException)
+        public static bool ConvertException(COMException ex, [NotNullWhen(true)] out Exception? uiaException)
         {
             var handled = true;
             switch ((uint)ex.ErrorCode)

--- a/src/FlaUI.Core/Tools/ItemRealizer.cs
+++ b/src/FlaUI.Core/Tools/ItemRealizer.cs
@@ -30,7 +30,7 @@ namespace FlaUI.Core.Tools
             if (itemContainerPattern != null)
             {
                 // There's the item container pattern so we can go thru all elements and just realize them
-                AutomationElement currentElement = null;
+                AutomationElement? currentElement = null;
                 while (true)
                 {
                     currentElement = itemContainerPattern.FindItemByProperty(currentElement, null, null);
@@ -63,7 +63,7 @@ namespace FlaUI.Core.Tools
             }
         }
 
-        private static void ResetScroll(IScrollPattern scrollPattern, double hScrollPercentage, double vScrollPercentage)
+        private static void ResetScroll(IScrollPattern? scrollPattern, double hScrollPercentage, double vScrollPercentage)
         {
             scrollPattern?.SetScrollPercent(hScrollPercentage, vScrollPercentage);
         }

--- a/src/FlaUI.Core/Tools/OperatingSystem.cs
+++ b/src/FlaUI.Core/Tools/OperatingSystem.cs
@@ -143,7 +143,7 @@ namespace FlaUI.Core.Tools
         /// </summary>
         private static string GetProductName()
         {
-            return GetRegistryValue<string>("ProductName");
+            return GetRegistryValue<string>("ProductName") ?? string.Empty;
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace FlaUI.Core.Tools
         /// </summary>
         private static string GetBuildNumber()
         {
-            return GetRegistryValue<string>("CurrentBuild");
+            return GetRegistryValue<string>("CurrentBuild") ?? string.Empty;
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace FlaUI.Core.Tools
         /// </summary>
         private static string GetRelease()
         {
-            return GetRegistryValue<string>("ReleaseId");
+            return GetRegistryValue<string>("ReleaseId") ?? string.Empty;
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace FlaUI.Core.Tools
             return GetRegistryValue<int>("UBR").ToString();
         }
 
-        private static T GetRegistryValue<T>(string keyName)
+        private static T? GetRegistryValue<T>(string keyName)
         {
             var reg = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
             if (reg != null)

--- a/src/FlaUI.Core/Tools/Retry.cs
+++ b/src/FlaUI.Core/Tools/Retry.cs
@@ -35,14 +35,14 @@ namespace FlaUI.Core.Tools
         /// <param name="lastValueOnTimeout">A flag indicating if the last value should be returned on timeout. Returns the default if the value could never be fetched.</param>
         /// <param name="defaultOnTimeout">Allows to define a default value in case of a timeout.</param>
         /// <returns>The value from <paramref name="retryMethod"/> or the default of <typeparamref name="T"/>.</returns>
-        public static RetryResult<T> While<T>(Func<T> retryMethod, Func<T, bool> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string timeoutMessage = null, bool lastValueOnTimeout = false, T defaultOnTimeout = default(T))
+        public static RetryResult<T> While<T>(Func<T> retryMethod, Func<T, bool> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string? timeoutMessage = null, bool lastValueOnTimeout = false, T? defaultOnTimeout = default(T))
         {
             var retryResult = new RetryResult<T>();
             timeout = timeout ?? DefaultTimeout;
             interval = interval ?? DefaultInterval;
             var startTime = DateTime.UtcNow;
-            Exception lastException = null;
-            T lastValue = defaultOnTimeout;
+            Exception? lastException = null;
+            T? lastValue = defaultOnTimeout;
             do
             {
                 retryResult.Iterations++;
@@ -95,7 +95,7 @@ namespace FlaUI.Core.Tools
         /// </summary>
         /// <typeparam name="T">The type of the return value.</typeparam>
         /// <returns>The value from <paramref name="retryMethod"/> or the default of <typeparamref name="T"/>.</returns>
-        public static RetryResult<T> WhileNot<T>(Func<T> retryMethod, Func<T, bool> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string timeoutMessage = null, bool lastValueOnTimeout = false, T defaultOnTimeout = default(T))
+        public static RetryResult<T> WhileNot<T>(Func<T> retryMethod, Func<T, bool> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string? timeoutMessage = null, bool lastValueOnTimeout = false, T? defaultOnTimeout = default(T))
         {
             return While(retryMethod, (x) => !checkMethod(x), timeout, interval, throwOnTimeout, ignoreException, timeoutMessage, lastValueOnTimeout, defaultOnTimeout);
         }
@@ -111,7 +111,7 @@ namespace FlaUI.Core.Tools
         /// <param name="defaultOnTimeout">Allows to define a default value in case of a timeout.</param>
         /// <typeparam name="T">The type of the return value.</typeparam>
         /// <returns>The value from <paramref name="retryMethod"/> or the default of <typeparamref name="T"/>.</returns>
-        public static RetryResult<T> WhileNot<T>(Func<T> retryMethod, Func<T, bool> checkMethod, RetrySettings retrySettings = null, bool lastValueOnTimeout = false, T defaultOnTimeout = default(T))
+        public static RetryResult<T> WhileNot<T>(Func<T> retryMethod, Func<T, bool> checkMethod, RetrySettings? retrySettings = null, bool lastValueOnTimeout = false, T? defaultOnTimeout = default(T))
         {
             return While(retryMethod, (x) => !checkMethod(x), retrySettings, lastValueOnTimeout, defaultOnTimeout);
         }
@@ -120,7 +120,7 @@ namespace FlaUI.Core.Tools
         /// Retries while the given method evaluates to true.
         /// </summary>
         /// <returns>True if the retry completed successfully within the time and false otherwise.</returns>
-        public static RetryResult<bool> WhileTrue(Func<bool> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string timeoutMessage = null)
+        public static RetryResult<bool> WhileTrue(Func<bool> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string? timeoutMessage = null)
         {
             // Use the generic retry. To have the correct return value on success, we need to inverse the result of the check method.
             return While(() => !checkMethod(), r => !r, timeout, interval, throwOnTimeout, ignoreException, timeoutMessage: timeoutMessage);
@@ -130,7 +130,7 @@ namespace FlaUI.Core.Tools
         /// Retries while the given method evaluates to false.
         /// </summary>
         /// <returns>True if the retry completed successfully within the time and false otherwise.</returns>
-        public static RetryResult<bool> WhileFalse(Func<bool> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string timeoutMessage = null)
+        public static RetryResult<bool> WhileFalse(Func<bool> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string? timeoutMessage = null)
         {
             // Use the generic retry. To have the correct return value on success, we need to inverse the result of the check method.
             return While(checkMethod, r => !r, timeout, interval, throwOnTimeout, ignoreException, timeoutMessage: timeoutMessage);
@@ -140,7 +140,7 @@ namespace FlaUI.Core.Tools
         /// Retries while the given method evaluates to null.
         /// </summary>
         /// <returns>The value from <paramref name="checkMethod"/> or the default of <typeparamref name="T"/> in case of a timeout.</returns>
-        public static RetryResult<T> WhileNull<T>(Func<T> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string timeoutMessage = null)
+        public static RetryResult<T> WhileNull<T>(Func<T> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string? timeoutMessage = null)
         {
             return While(checkMethod, r => r == null, timeout, interval, throwOnTimeout, ignoreException, timeoutMessage: timeoutMessage);
         }
@@ -149,7 +149,7 @@ namespace FlaUI.Core.Tools
         /// Retries while the given method evaluates to not null.
         /// </summary>
         /// <returns>True if it evaluated to null within the time or false in case of a timeout.</returns>
-        public static RetryResult<bool> WhileNotNull<T>(Func<T> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string timeoutMessage = null)
+        public static RetryResult<bool> WhileNotNull<T>(Func<T> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string? timeoutMessage = null)
         {
             return WhileTrue(() => checkMethod() != null, timeout, interval, throwOnTimeout, ignoreException, timeoutMessage);
         }
@@ -157,7 +157,7 @@ namespace FlaUI.Core.Tools
         /// <summary>
         /// Retries while return value from the given method evaluates to null or has no elements.
         /// </summary>
-        public static RetryResult<T> WhileEmpty<T>(Func<T> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string timeoutMessage = null) where T : IEnumerable
+        public static RetryResult<T> WhileEmpty<T>(Func<T> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string? timeoutMessage = null) where T : IEnumerable
         {
             return While(checkMethod, r => r == null || !r.GetEnumerator().MoveNext(), timeout, interval, throwOnTimeout, ignoreException, timeoutMessage: timeoutMessage);
         }
@@ -165,7 +165,7 @@ namespace FlaUI.Core.Tools
         /// <summary>
         /// Retries while return value from the given method is null or an empty string.
         /// </summary>
-        public static RetryResult<string> WhileEmpty(Func<string> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string timeoutMessage = null)
+        public static RetryResult<string> WhileEmpty(Func<string> checkMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, bool ignoreException = false, string? timeoutMessage = null)
         {
             return While(checkMethod, String.IsNullOrEmpty, timeout, interval, throwOnTimeout, ignoreException, timeoutMessage: timeoutMessage);
         }
@@ -174,7 +174,7 @@ namespace FlaUI.Core.Tools
         /// Retries while the given method has an exception.
         /// </summary>
         /// <returns>True if the method completed without exception, false otherwise.</returns>
-        public static RetryResult<bool> WhileException(Action retryMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, string timeoutMessage = null)
+        public static RetryResult<bool> WhileException(Action retryMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, string? timeoutMessage = null)
         {
             var success = false;
             var result = WhileTrue(() => { retryMethod(); success = true; return false; }, timeout, interval, ignoreException: true, throwOnTimeout: throwOnTimeout, timeoutMessage: timeoutMessage);
@@ -185,7 +185,7 @@ namespace FlaUI.Core.Tools
         /// <summary>
         /// Retries while the given method has an exception and returns the value from the method.
         /// </summary>
-        public static RetryResult<T> WhileException<T>(Func<T> retryMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, string timeoutMessage = null)
+        public static RetryResult<T> WhileException<T>(Func<T> retryMethod, TimeSpan? timeout = null, TimeSpan? interval = null, bool throwOnTimeout = false, string? timeoutMessage = null)
         {
             var returnValue = default(T);
             var result = WhileTrue(() => { returnValue = retryMethod(); return false; }, timeout, interval, ignoreException: true, throwOnTimeout: throwOnTimeout, timeoutMessage: timeoutMessage);
@@ -217,7 +217,7 @@ namespace FlaUI.Core.Tools
         /// <param name="searchMethod">The method used to search for the element list.</param>
         /// <param name="retrySettings">The settings to use for retrying.</param>
         /// <returns>The list of found elements.</returns>
-        public static AutomationElement[] Find(Func<AutomationElement[]> searchMethod, RetrySettings retrySettings)
+        public static AutomationElement[] Find(Func<AutomationElement[]> searchMethod, RetrySettings? retrySettings)
         {
             if (retrySettings == null)
             {
@@ -232,7 +232,7 @@ namespace FlaUI.Core.Tools
         /// <param name="searchMethod">The method used to search for the element.</param>
         /// <param name="retrySettings">The settings to use for retrying.</param>
         /// <returns>The found element.</returns>
-        public static AutomationElement Find(Func<AutomationElement> searchMethod, RetrySettings retrySettings)
+        public static AutomationElement Find(Func<AutomationElement> searchMethod, RetrySettings? retrySettings)
         {
             if (retrySettings == null)
             {

--- a/src/FlaUI.Core/Tools/RetryResult.cs
+++ b/src/FlaUI.Core/Tools/RetryResult.cs
@@ -45,9 +45,9 @@ namespace FlaUI.Core.Tools
         public bool Success => !TimedOut;
 
         /// <summary>
-        /// Contains the last occured exception in the retry (if any). Only usefull if "ignoreException" is set to true on the retry.
+        /// Contains the last occurred exception in the retry (if any). Only useful if "ignoreException" is set to true on the retry.
         /// </summary>
-        public Exception LastException { get; private set; }
+        public Exception? LastException { get; private set; }
 
         /// <summary>
         /// Flag which indicates if the retry had an exception or not.
@@ -57,7 +57,7 @@ namespace FlaUI.Core.Tools
         /// <summary>
         /// Contains the final value returned by the retry.
         /// </summary>
-        public T Result { get; internal set; }
+        public T? Result { get; internal set; }
 
         /// <summary>
         /// Time span how long the retry did run.
@@ -75,7 +75,7 @@ namespace FlaUI.Core.Tools
         /// <param name="result">The value to set as result.</param>
         /// <param name="timedOut">The flag which indicates if the retry timed out or not.</param>
         /// <returns>The object itself for fluent usage.</returns>
-        internal RetryResult<T> Finish(T result, bool timedOut = false)
+        internal RetryResult<T> Finish(T? result, bool timedOut = false)
         {
             EndTime = DateTime.UtcNow;
             Result = result;

--- a/src/FlaUI.Core/Tools/RetrySettings.cs
+++ b/src/FlaUI.Core/Tools/RetrySettings.cs
@@ -30,6 +30,6 @@ namespace FlaUI.Core.Tools
         /// <summary>
         /// The message that should be added to the timeout exception in case a timeout occurs.
         /// </summary>
-        public string TimeoutMessage { get; set; }
+        public string? TimeoutMessage { get; set; }
     }
 }

--- a/src/FlaUI.Core/WindowsAPI/User32.cs
+++ b/src/FlaUI.Core/WindowsAPI/User32.cs
@@ -107,7 +107,7 @@ namespace FlaUI.Core.WindowsAPI
         public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
 
         [DllImport("user32.dll", SetLastError = true)]
-        public static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
+        public static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string? lpszClass, string? lpszWindow);
 
         [DllImport("User32.dll", SetLastError = true)]
         public static extern bool InitializeTouchInjection(uint maxCount = 256, InjectedInputVisualizationMode feedbackMode = InjectedInputVisualizationMode.DEFAULT);

--- a/src/FlaUI.Core/WindowsAPI/Win32Fallback.cs
+++ b/src/FlaUI.Core/WindowsAPI/Win32Fallback.cs
@@ -222,7 +222,7 @@ namespace FlaUI.Core.WindowsAPI
             return hwndEdit;
         }
 
-        internal static string GetWindowClassName(IntPtr handle)
+        internal static string? GetWindowClassName(IntPtr handle)
         {
             if (handle == IntPtr.Zero)
             {

--- a/src/FlaUI.Core/WindowsAPI/WindowsApiTools.cs
+++ b/src/FlaUI.Core/WindowsAPI/WindowsApiTools.cs
@@ -46,7 +46,7 @@ namespace FlaUI.Core.WindowsAPI
         /// <summary>
         /// Tries to get the executable path for a given process.
         /// </summary>
-        public static string GetMainModuleFilepath(Process process)
+        public static string? GetMainModuleFilepath(Process process)
         {
             // Workaround for when the current process is 32 bit and the otherto get the info is 64 bit.
             if (Tools.OperatingSystem.Is64Bit && !IsCurrentProcess64Bit())
@@ -65,7 +65,7 @@ namespace FlaUI.Core.WindowsAPI
                 }
                 return null;
             }
-            return process.MainModule.FileName;
+            return process.MainModule?.FileName;
         }
     }
 }

--- a/src/FlaUI.UIA2/Converters/AutomationElementConverter.cs
+++ b/src/FlaUI.UIA2/Converters/AutomationElementConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FlaUI.Core;
 using FlaUI.Core.AutomationElements;
@@ -17,7 +18,7 @@ namespace FlaUI.UIA2.Converters
         /// <param name="automation">The automation to use for the conversion.</param>
         /// <param name="nativeElements">The native array to convert.</param>
         /// <returns>The array of managed elements.</returns>
-        public static AutomationElement[] NativeArrayToManaged(AutomationBase automation, object nativeElements)
+        public static AutomationElement[] NativeArrayToManaged(AutomationBase automation, object? nativeElements)
         {
             if (nativeElements == null)
             {
@@ -48,10 +49,11 @@ namespace FlaUI.UIA2.Converters
         /// <param name="automation">The automation to use for the conversion.</param>
         /// <param name="nativeElement">The native element to convert.</param>
         /// <returns>The converted managed element.</returns>
-        public static AutomationElement NativeToManaged(AutomationBase automation, object nativeElement)
+        [return: NotNullIfNotNull(nameof(nativeElement))]
+        public static AutomationElement? NativeToManaged(AutomationBase automation, object? nativeElement)
         {
             var uia2Automation = (UIA2Automation)automation;
-            return uia2Automation.WrapNativeElement((UIA.AutomationElement)nativeElement);
+            return uia2Automation.WrapNativeElement((UIA.AutomationElement?)nativeElement);
         }
 
         /// <summary>
@@ -59,7 +61,8 @@ namespace FlaUI.UIA2.Converters
         /// </summary>
         /// <param name="automationElement">The managed element to convert.</param>
         /// <returns>The converted native element.</returns>
-        public static UIA.AutomationElement ToNative(this AutomationElement automationElement)
+        [return: NotNullIfNotNull(nameof(automationElement))]
+        public static UIA.AutomationElement? ToNative(this AutomationElement? automationElement)
         {
             if (automationElement == null)
             {

--- a/src/FlaUI.UIA2/Converters/ValueConverter.cs
+++ b/src/FlaUI.UIA2/Converters/ValueConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Globalization;
 using FlaUI.Core.AutomationElements;
@@ -16,7 +17,8 @@ namespace FlaUI.UIA2.Converters
         /// <summary>
         /// Converts the given object to an object the native client expects
         /// </summary>
-        public static object ToNative(object val)
+        [return: NotNullIfNotNull(nameof(val))]
+        public static object? ToNative(object? val)
         {
             if (val == null)
             {

--- a/src/FlaUI.UIA2/FlaUI.UIA2.csproj
+++ b/src/FlaUI.UIA2/FlaUI.UIA2.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net48;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF> <!-- Needed so System.Windows.Automation is added -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -47,6 +49,10 @@
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
     <None Include="..\..\CHANGELOG.md" Pack="true" PackagePath="" />
     <None Include="..\..\FlaUI.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup Label="Linked files">
+    <Compile Include="..\FlaUI.Core\CodeAnalysisAttributes.cs" Link="CodeAnalysisAttributes.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/FlaUI.UIA2/Patterns/ItemContainerPattern.cs
+++ b/src/FlaUI.UIA2/Patterns/ItemContainerPattern.cs
@@ -18,7 +18,7 @@ namespace FlaUI.UIA2.Patterns
         {
         }
 
-        public AutomationElement FindItemByProperty(AutomationElement startAfter, PropertyId property, object value)
+        public AutomationElement FindItemByProperty(AutomationElement? startAfter, PropertyId? property, object? value)
         {
             var foundNativeElement = NativePattern.FindItemByProperty(
                     startAfter?.ToNative(),

--- a/src/FlaUI.UIA2/UIA2Automation.cs
+++ b/src/FlaUI.UIA2/UIA2Automation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using FlaUI.Core;
 using FlaUI.Core.AutomationElements;
@@ -115,8 +116,9 @@ namespace FlaUI.UIA2
         {
             return UIA.Automation.Compare(element1.ToNative(), element2.ToNative());
         }
-
-        public AutomationElement WrapNativeElement(UIA.AutomationElement nativeElement)
+        
+        [return: NotNullIfNotNull(nameof(nativeElement))]
+        public AutomationElement? WrapNativeElement(UIA.AutomationElement? nativeElement)
         {
             return nativeElement == null ? null : new AutomationElement(new UIA2FrameworkAutomationElement(this, nativeElement));
         }

--- a/src/FlaUI.UIA2/UIA2FrameworkAutomationElement.Patterns.cs
+++ b/src/FlaUI.UIA2/UIA2FrameworkAutomationElement.Patterns.cs
@@ -2,12 +2,14 @@
 using FlaUI.Core.Exceptions;
 using FlaUI.Core.Patterns;
 using FlaUI.UIA2.Patterns;
+using System.Diagnostics.CodeAnalysis;
 using UIA = System.Windows.Automation;
 
 namespace FlaUI.UIA2
 {
     public partial class UIA2FrameworkAutomationElement
     {
+        [DoesNotReturn]
         protected override IAutomationPattern<IAnnotationPattern> InitializeAnnotationPattern()
         {
             throw new NotSupportedByFrameworkException();
@@ -19,11 +21,13 @@ namespace FlaUI.UIA2
                 DockPattern.Pattern, this, (b, p) => new DockPattern(b, p));
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<IDragPattern> InitializeDragPattern()
         {
             throw new NotSupportedByFrameworkException();
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<IDropTargetPattern> InitializeDropTargetPattern()
         {
             throw new NotSupportedByFrameworkException();
@@ -63,6 +67,7 @@ namespace FlaUI.UIA2
 #endif
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<ILegacyIAccessiblePattern> InitializeLegacyIAccessiblePattern()
         {
             throw new NotSupportedByFrameworkException();
@@ -74,6 +79,7 @@ namespace FlaUI.UIA2
                 MultipleViewPattern.Pattern, this, (b, p) => new MultipleViewPattern(b, p));
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<IObjectModelPattern> InitializeObjectModelPattern()
         {
             throw new NotSupportedByFrameworkException();
@@ -103,6 +109,7 @@ namespace FlaUI.UIA2
                 SelectionItemPattern.Pattern, this, (b, p) => new SelectionItemPattern(b, p));
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<ISelection2Pattern> InitializeSelection2Pattern()
         {
             throw new NotSupportedByFrameworkException();
@@ -114,16 +121,19 @@ namespace FlaUI.UIA2
                 SelectionPattern.Pattern, this, (b, p) => new SelectionPattern(b, p));
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<ISpreadsheetItemPattern> InitializeSpreadsheetItemPattern()
         {
             throw new NotSupportedByFrameworkException();
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<ISpreadsheetPattern> InitializeSpreadsheetPattern()
         {
             throw new NotSupportedByFrameworkException();
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<IStylesPattern> InitializeStylesPattern()
         {
             throw new NotSupportedByFrameworkException();
@@ -151,16 +161,19 @@ namespace FlaUI.UIA2
                 TablePattern.Pattern, this, (b, p) => new TablePattern(b, p));
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<ITextChildPattern> InitializeTextChildPattern()
         {
             throw new NotSupportedByFrameworkException();
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<ITextEditPattern> InitializeTextEditPattern()
         {
             throw new NotSupportedByFrameworkException();
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<IText2Pattern> InitializeText2Pattern()
         {
             throw new NotSupportedByFrameworkException();
@@ -178,6 +191,7 @@ namespace FlaUI.UIA2
                 TogglePattern.Pattern, this, (b, p) => new TogglePattern(b, p));
         }
 
+        [DoesNotReturn]
         protected override IAutomationPattern<ITransform2Pattern> InitializeTransform2Pattern()
         {
             throw new NotSupportedByFrameworkException();

--- a/src/FlaUI.UIA2/UIA2FrameworkAutomationElement.cs
+++ b/src/FlaUI.UIA2/UIA2FrameworkAutomationElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Linq;
 using FlaUI.Core;
@@ -72,16 +73,17 @@ namespace FlaUI.UIA2
         }
 
         /// <inheritdoc />
-        public override AutomationElement FindFirst(TreeScope treeScope, ConditionBase condition)
+        public override AutomationElement? FindFirst(TreeScope treeScope, ConditionBase condition)
         {
             var cacheRequest = CacheRequest.IsCachingActive ? CacheRequest.Current.ToNative() : null;
             cacheRequest?.Push();
-            var nativeFoundElement = NativeElement.FindFirst((UIA.TreeScope)treeScope, ConditionConverter.ToNative(condition));
+            var nativeFoundElement = (UIA.AutomationElement?)NativeElement.FindFirst((UIA.TreeScope)treeScope, ConditionConverter.ToNative(condition));
             cacheRequest?.Pop();
             return AutomationElementConverter.NativeToManaged(Automation, nativeFoundElement);
         }
 
         /// <inheritdoc />
+        [DoesNotReturn]
         public override AutomationElement[] FindAllWithOptions(TreeScope treeScope, ConditionBase condition,
             TreeTraversalOptions traversalOptions, AutomationElement root)
         {
@@ -89,6 +91,7 @@ namespace FlaUI.UIA2
         }
 
         /// <inheritdoc />
+        [DoesNotReturn]
         public override AutomationElement FindFirstWithOptions(TreeScope treeScope, ConditionBase condition,
             TreeTraversalOptions traversalOptions, AutomationElement root)
         {
@@ -96,7 +99,7 @@ namespace FlaUI.UIA2
         }
 
         /// <inheritdoc />
-        public override AutomationElement FindAt(TreeScope treeScope, int index, ConditionBase condition)
+        public override AutomationElement? FindAt(TreeScope treeScope, int index, ConditionBase condition)
         {
             var cacheRequest = CacheRequest.IsCachingActive ? CacheRequest.Current.ToNative() : null;
             cacheRequest?.Push();
@@ -168,18 +171,21 @@ namespace FlaUI.UIA2
         }
 
         /// <inheritdoc />
+        [DoesNotReturn]
         public override NotificationEventHandlerBase RegisterNotificationEvent(TreeScope treeScope, Action<AutomationElement, NotificationKind, NotificationProcessing, string, string> action)
         {
             throw new NotSupportedByFrameworkException();
         }
 
         /// <inheritdoc />
+        [DoesNotReturn]
         public override TextEditTextChangedEventHandlerBase RegisterTextEditTextChangedEventHandler(TreeScope treeScope, TextEditChangeType textEditChangeType, Action<AutomationElement, TextEditChangeType, string[]> action)
         {
             throw new NotSupportedByFrameworkException();
         }
 
         /// <inheritdoc />
+        [DoesNotReturn]
         public override void UnregisterActiveTextPositionChangedEventHandler(ActiveTextPositionChangedEventHandlerBase eventHandler)
         {
             throw new NotSupportedByFrameworkException();
@@ -205,12 +211,14 @@ namespace FlaUI.UIA2
         }
 
         /// <inheritdoc />
+        [DoesNotReturn]
         public override void UnregisterNotificationEventHandler(NotificationEventHandlerBase eventHandler)
         {
             throw new NotSupportedByFrameworkException();
         }
 
         /// <inheritdoc />
+        [DoesNotReturn]
         public override void UnregisterTextEditTextChangedEventHandler(TextEditTextChangedEventHandlerBase eventHandler)
         {
             throw new NotSupportedByFrameworkException();
@@ -228,7 +236,7 @@ namespace FlaUI.UIA2
             return raw.Select(r => PropertyId.Find(Automation.AutomationType, r.Id)).ToArray();
         }
 
-        public override AutomationElement GetUpdatedCache()
+        public override AutomationElement? GetUpdatedCache()
         {
             if (CacheRequest.Current != null)
             {
@@ -250,6 +258,7 @@ namespace FlaUI.UIA2
             return AutomationElementConverter.NativeToManaged(Automation, cachedParent);
         }
 
+        [DoesNotReturn]
         public override object GetCurrentMetadataValue(PropertyId targetId, int metadataId)
         {
             throw new NotSupportedByFrameworkException();

--- a/src/FlaUI.UIA2/UIA2TextRange.cs
+++ b/src/FlaUI.UIA2/UIA2TextRange.cs
@@ -74,7 +74,7 @@ namespace FlaUI.UIA2
         public Rectangle[] GetBoundingRectangles()
         {
             var unrolledRects = NativeRange.GetBoundingRectangles();
-            return unrolledRects?.Select(r => (Rectangle)ValueConverter.ToRectangle(r)).ToArray();
+            return unrolledRects.Select(r => (Rectangle)ValueConverter.ToRectangle(r)).ToArray();
         }
 
         public AutomationElement[] GetChildren()

--- a/src/FlaUI.UIA3/Converters/AutomationElementConverter.cs
+++ b/src/FlaUI.UIA3/Converters/AutomationElementConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using FlaUI.Core;
 using FlaUI.Core.AutomationElements;
 using UIA = Interop.UIAutomationClient;
@@ -16,7 +17,7 @@ namespace FlaUI.UIA3.Converters
         /// <param name="automation">The automation to use for the conversion.</param>
         /// <param name="nativeElements">The native array to convert.</param>
         /// <returns>The array of managed elements.</returns>
-        public static AutomationElement[] NativeArrayToManaged(AutomationBase automation, object nativeElements)
+        public static AutomationElement[] NativeArrayToManaged(AutomationBase automation, object? nativeElements)
         {
             if (nativeElements == null)
             {
@@ -40,10 +41,11 @@ namespace FlaUI.UIA3.Converters
         /// <param name="automation">The automation to use for the conversion.</param>
         /// <param name="nativeElement">The native element to convert.</param>
         /// <returns>The converted managed element.</returns>
-        public static AutomationElement NativeToManaged(AutomationBase automation, object nativeElement)
+        [return: NotNullIfNotNull(nameof(nativeElement))]
+        public static AutomationElement? NativeToManaged(AutomationBase automation, object? nativeElement)
         {
             var uia3Automation = (UIA3Automation)automation;
-            return uia3Automation.WrapNativeElement((UIA.IUIAutomationElement)nativeElement);
+            return uia3Automation.WrapNativeElement((UIA.IUIAutomationElement?)nativeElement);
         }
 
         /// <summary>
@@ -51,7 +53,8 @@ namespace FlaUI.UIA3.Converters
         /// </summary>
         /// <param name="automationElement">The managed element to convert.</param>
         /// <returns>The converted native element.</returns>
-        public static UIA.IUIAutomationElement ToNative(this AutomationElement automationElement)
+        [return: NotNullIfNotNull(nameof(automationElement))]
+        public static UIA.IUIAutomationElement? ToNative(this AutomationElement? automationElement)
         {
             if (automationElement == null)
             {

--- a/src/FlaUI.UIA3/Converters/ValueConverter.cs
+++ b/src/FlaUI.UIA3/Converters/ValueConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Globalization;
 using FlaUI.Core.AutomationElements;
@@ -16,7 +17,8 @@ namespace FlaUI.UIA3.Converters
         /// <summary>
         /// Converts the given object to an object the native client expects
         /// </summary>
-        public static object ToNative(object val)
+        [return: NotNullIfNotNull(nameof(val))]
+        public static object? ToNative(object? val)
         {
             if (val == null)
             {
@@ -58,13 +60,15 @@ namespace FlaUI.UIA3.Converters
         /// </summary>
         /// <param name="rectangle">The native rectangle to convert.</param>
         /// <returns>The converted managed rectangle.</returns>
-        public static object ToRectangle(object rectangle)
+        [return: NotNullIfNotNull(nameof(rectangle))]
+        public static object? ToRectangle(object? rectangle)
         {
-            var origValue = (double[])rectangle;
             if (rectangle == null)
             {
                 return null;
             }
+
+            var origValue = (double[])rectangle;
             return new Rectangle(origValue[0].ToInt(), origValue[1].ToInt(), origValue[2].ToInt(), origValue[3].ToInt());
         }
 
@@ -73,13 +77,15 @@ namespace FlaUI.UIA3.Converters
         /// </summary>
         /// <param name="point">The native point to convert.</param>
         /// <returns>The converted managed point.</returns>
-        public static object ToPoint(object point)
+        [return: NotNullIfNotNull(nameof(point))]
+        public static object? ToPoint(object? point)
         {
-            var origValue = (double[])point;
             if (point == null)
             {
                 return null;
             }
+
+            var origValue = (double[])point;
             return new Point(origValue[0].ToInt(), origValue[1].ToInt());
         }
 

--- a/src/FlaUI.UIA3/FlaUI.UIA3.csproj
+++ b/src/FlaUI.UIA3/FlaUI.UIA3.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup Label="Build">
     <TargetFrameworks>net48;net6.0-windows;net8.0-windows</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -45,6 +47,10 @@
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
     <None Include="..\..\CHANGELOG.md" Pack="true" PackagePath="" />
     <None Include="..\..\FlaUI.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup Label="Linked files">
+    <Compile Include="..\FlaUI.Core\CodeAnalysisAttributes.cs" Link="CodeAnalysisAttributes.cs" />
   </ItemGroup>
 
   <!-- Interop References -->

--- a/src/FlaUI.UIA3/Patterns/ItemContainerPattern.cs
+++ b/src/FlaUI.UIA3/Patterns/ItemContainerPattern.cs
@@ -18,7 +18,7 @@ namespace FlaUI.UIA3.Patterns
         {
         }
 
-        public AutomationElement FindItemByProperty(AutomationElement startAfter, PropertyId property, object value)
+        public AutomationElement FindItemByProperty(AutomationElement? startAfter, PropertyId? property, object? value)
         {
             var foundNativeElement = Com.Call(() =>
                 NativePattern.FindItemByProperty(

--- a/src/FlaUI.UIA3/UIA3Automation.cs
+++ b/src/FlaUI.UIA3/UIA3Automation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using FlaUI.Core;
@@ -209,7 +210,8 @@ namespace FlaUI.UIA3
             return element;
         }
 
-        public AutomationElement WrapNativeElement(UIA.IUIAutomationElement nativeElement)
+        [return: NotNullIfNotNull(nameof(nativeElement))]
+        public AutomationElement? WrapNativeElement(UIA.IUIAutomationElement? nativeElement)
         {
             return nativeElement == null ? null : new AutomationElement(new UIA3FrameworkAutomationElement(this, nativeElement));
         }

--- a/src/FlaUI.UIA3/UIA3FrameworkAutomationElement.cs
+++ b/src/FlaUI.UIA3/UIA3FrameworkAutomationElement.cs
@@ -105,9 +105,9 @@ namespace FlaUI.UIA3
         }
 
         /// <inheritdoc />
-        public override AutomationElement FindFirst(TreeScope treeScope, ConditionBase condition)
+        public override AutomationElement? FindFirst(TreeScope treeScope, ConditionBase condition)
         {
-            var nativeFoundElement = CacheRequest.IsCachingActive
+            UIA.IUIAutomationElement? nativeFoundElement = CacheRequest.IsCachingActive
                 ? NativeElement.FindFirstBuildCache((UIA.TreeScope)treeScope, ConditionConverter.ToNative(Automation, condition), CacheRequest.Current.ToNative(Automation))
                 : NativeElement.FindFirst((UIA.TreeScope)treeScope, ConditionConverter.ToNative(Automation, condition));
             return AutomationElementConverter.NativeToManaged(Automation, nativeFoundElement);
@@ -124,17 +124,17 @@ namespace FlaUI.UIA3
         }
 
         /// <inheritdoc />
-        public override AutomationElement FindFirstWithOptions(TreeScope treeScope, ConditionBase condition,
+        public override AutomationElement? FindFirstWithOptions(TreeScope treeScope, ConditionBase condition,
             TreeTraversalOptions traversalOptions, AutomationElement root)
         {
-            var nativeFoundElement = CacheRequest.IsCachingActive
+            UIA.IUIAutomationElement? nativeFoundElement = CacheRequest.IsCachingActive
                 ? NativeElement7.FindFirstWithOptionsBuildCache((UIA.TreeScope)treeScope, ConditionConverter.ToNative(Automation, condition), CacheRequest.Current.ToNative(Automation), (UIA.TreeTraversalOptions)traversalOptions, root.ToNative())
                 : NativeElement7.FindFirstWithOptions((UIA.TreeScope)treeScope, ConditionConverter.ToNative(Automation, condition), (UIA.TreeTraversalOptions)traversalOptions, root.ToNative());
             return AutomationElementConverter.NativeToManaged(Automation, nativeFoundElement);
         }
 
         /// <inheritdoc />
-        public override AutomationElement FindAt(TreeScope treeScope, int index, ConditionBase condition)
+        public override AutomationElement? FindAt(TreeScope treeScope, int index, ConditionBase condition)
         {
             var nativeFoundElements = CacheRequest.IsCachingActive
                 ? NativeElement.FindAllBuildCache((UIA.TreeScope)treeScope, ConditionConverter.ToNative(Automation, condition), CacheRequest.Current.ToNative(Automation))
@@ -274,7 +274,7 @@ namespace FlaUI.UIA3
             return rawIds.Select(id => PropertyId.Find(Automation.AutomationType, id)).ToArray();
         }
 
-        public override AutomationElement GetUpdatedCache()
+        public override AutomationElement? GetUpdatedCache()
         {
             if (CacheRequest.Current != null)
             {


### PR DESCRIPTION
When I started using FlaUI, I realized that methods and properties I didn't expect to return `null`. So I thought nullable annotations could be useful.

- Enabled nullable annotations for Core/UIA2/UIA3, upgraded to C# 11 for `nameof(parameter)`.
- Created internal fake code analysis attributes for TFMs not providing them, e.g. .NET Framework and .NET Standard 2.0.
- Nearly no changes in behaviour, only in a few cases where avoiding a null-ref exception was reasonable.
- Of course, there are still many chances for null-ref in the codebase, but we have warnings now.