### PR TITLE
Add delay after pressing keyboard modifiers

### DIFF
--- a/src/FlaUI.Core/Input/Keyboard.cs
+++ b/src/FlaUI.Core/Input/Keyboard.cs
@@ -69,6 +69,11 @@ namespace FlaUI.Core.Input
                 {
                     Press(mod);
                 }
+                // Wait a moment for modifiers to be pressed
+                if (modifiers.Any())
+                {
+                    Wait.UntilInputIsProcessed();
+                }
                 // Type the effective key
                 SendInput(low, true, false, false, false);
                 SendInput(low, false, false, false, false);


### PR DESCRIPTION
There's an issue we're seeing with triggering tooltips within text boxes: we're trying to enter invalid characters into a text box, and then verify that an error tooltip appears. Usually the tooltip will remain on screen for awhile after entering the character, but using FlaUI we found that it will instead appear very briefly before disappearing again.

Here is a GIF of this happening, where we're entering a series of invalid characters into a text box using FlaUI. As you can see, the tooltip disappears very quickly. This is causing problems as we're trying to capture the tooltip and its contents, but this is difficult since there's only a brief window to do so.
![BugExample](https://github.com/FlaUI/FlaUI/assets/48141481/03c90867-24cf-4b7a-b2f4-cc8f7d643958)

After some testing, I found that this happens when typing a character that requires modifiers to be pressed, and that the lack of delay between pressing the modifiers and typing the character is causing the tooltip to disappear prematurely. The change that I've added resolves this, and waits for a moment after pressing the necessary modifiers (if there are any). As a result, the tooltip now appears and remains on-screen as expected:
![FixExample](https://github.com/FlaUI/FlaUI/assets/48141481/dd398b92-4e45-476c-800a-6aac02fd05d5)
