### PR TITLE
Added new flag to define usage of screenshots

### DIFF
--- a/src/FlaUI.TestUtilities/FlaUITestBase.cs
+++ b/src/FlaUI.TestUtilities/FlaUITestBase.cs
@@ -50,6 +50,12 @@ namespace FlaUI.TestUtilities
         protected virtual bool KeepVideoForSuccessfulTests => false;
 
         /// <summary>
+        /// Flag to indicate if screenshots should be taken in failing tests.
+        /// Defaults to true.
+        /// </summary>
+        protected virtual bool TakeScreenshots => true;
+
+        /// <summary>
         /// Specifies the mode of the video recorder.
         /// Defaults to OnePerTest.
         /// </summary>
@@ -142,7 +148,7 @@ namespace FlaUI.TestUtilities
         [TearDown]
         public virtual void UITestBaseTearDown()
         {
-            if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
+            if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed && TakeScreenshots == true)
             {
                 TakeScreenShot(TestContext.CurrentContext.Test.FullName);
                 TestContext.AddTestAttachment(


### PR DESCRIPTION
It could be interesting to have the option of enabling or disabling the screenshots capture when a test fails. However, this can be transparent for everyone as, by default, it keeps activated. If anyone needs to disable it (as it is my case), the property can be overriden.