### PR TITLE
Update ComboBox.cs

### DIFF
--- a/src/FlaUI.Core/AutomationElements/ComboBox.cs
+++ b/src/FlaUI.Core/AutomationElements/ComboBox.cs
@@ -140,7 +140,7 @@ namespace FlaUI.Core.AutomationElements
                 {
                     // WinForms and Win32
                     var listElement = FindFirstChild(cf => cf.ByControlType(ControlType.List));
-                    items = listElement.FindAllChildren();
+                    items = listElement.FindAllChildren().Where(c => c.ControlType != ControlType.ScrollBar).Cast<AutomationElement>().ToArray();
                 }
                 else
                 {


### PR DESCRIPTION
On a large ComboBox, the first child might be the vertical scroll bar, which must be eliminated from the items list.
additionally change can be set as:
`items = listElement.FindAllChildren().Where(c => c.ControlType == ControlType.ListItem).Cast<AutomationElement>().ToArray();`

