### PR TITLE
Combobox verify list item

### DIFF
--- a/src/FlaUI.Core/AutomationElements/ComboBox.cs
+++ b/src/FlaUI.Core/AutomationElements/ComboBox.cs
@@ -140,7 +140,7 @@ namespace FlaUI.Core.AutomationElements
                 {
                     // WinForms and Win32
                     var listElement = FindFirstChild(cf => cf.ByControlType(ControlType.List));
-                    items = listElement.FindAllChildren();
+                    items = listElement.FindAllChildren().Where(c => c.ControlType != ControlType.ScrollBar).Cast<AutomationElement>().ToArray();
                 }
                 else
                 {

--- a/src/FlaUI.Core/AutomationElements/ComboBox.cs
+++ b/src/FlaUI.Core/AutomationElements/ComboBox.cs
@@ -140,7 +140,7 @@ namespace FlaUI.Core.AutomationElements
                 {
                     // WinForms and Win32
                     var listElement = FindFirstChild(cf => cf.ByControlType(ControlType.List));
-                    items = listElement.FindAllChildren().Where(c => c.ControlType != ControlType.ScrollBar).Cast<AutomationElement>().ToArray();
+                    items = listElement.FindAllChildren().Where(c => c.ControlType == ControlType.ListItem).Cast<AutomationElement>().ToArray();
                 }
                 else
                 {


### PR DESCRIPTION
Filter only ListItem control types when getting Items from combobox.
Reason: On a ComboBox with many items, the first child might be the vertical scroll bar, which must be eliminated from the items list.