### PR TITLE
Fix #668

### DIFF
--- a/src/FlaUI.Core/Input/Mouse.cs
+++ b/src/FlaUI.Core/Input/Mouse.cs
@@ -229,7 +229,9 @@ namespace FlaUI.Core.Input
         /// </summary>
         public static void Scroll(double lines)
         {
-            var amount = (uint)(WheelDelta * lines);
+            // Intermediate cast to int needed in .NET 9+ due to
+            // https://learn.microsoft.com/en-us/dotnet/core/compatibility/jit/9.0/fp-to-integer
+            var amount = (uint)(int)(WheelDelta * lines);
             SendInput(0, 0, amount, MouseEventFlags.MOUSEEVENTF_WHEEL);
         }
 
@@ -238,7 +240,9 @@ namespace FlaUI.Core.Input
         /// </summary>
         public static void HorizontalScroll(double lines)
         {
-            var amount = (uint)(WheelDelta * lines);
+            // Intermediate cast to int needed in .NET 9+ due to
+            // https://learn.microsoft.com/en-us/dotnet/core/compatibility/jit/9.0/fp-to-integer
+            var amount = (uint)(int)(WheelDelta * lines);
             SendInput(0, 0, amount, MouseEventFlags.MOUSEEVENTF_HWHEEL);
         }
 


### PR DESCRIPTION
The behavior of casts from floating points to unsigned integers changed in .NET 9. https://learn.microsoft.com/en-us/dotnet/core/compatibility/jit/9.0/fp-to-integer

As a result, negative scroll amounts turn into 0x0U, resulting in no movement as observed in 668.

Casting from signed integers to unsigned integers still performs the same. So adding an intermediate cast to `int` is the simplest way I can think of to get as close to the pre-.NET-9 behavior as possible*, while still working across all versions of .NET that this project supports.

<sub>* Technically speaking, extremely _positive_ scroll values (i.e. more than `(double)int.MaxValue`) will still cause extremely _negative_ movements in .NET 8 and older.</sub>