### PR TITLE
Issue #674: do not fail silently on Cobobox.Select("Text")

### DIFF
--- a/src/FlaUI.Core.UITests/Elements/ComboBoxTests.cs
+++ b/src/FlaUI.Core.UITests/Elements/ComboBoxTests.cs
@@ -59,10 +59,12 @@ namespace FlaUI.Core.UITests.Elements
         public void SelectByTextTest(string comboBoxId)
         {
             var combo = _mainWindow.FindFirstDescendant(cf => cf.ByAutomationId(comboBoxId)).AsComboBox();
-            combo.Select("Item 2");
-            var selectedItem = combo.SelectedItem;
-            Assert.That(selectedItem, Is.Not.Null);
+    
+            var selectedItem = combo.Select("Item 2");
             Assert.That(selectedItem.Text, Is.EqualTo("Item 2"));
+
+            var ex = Assert.Throws<ArgumentException>(() => combo.Select("NonExistingItem"));
+            Assert.That(ex.Message, Does.Contain("Item with text 'NonExistingItem' not found in ComboBox."));
         }
 
         [Test]

--- a/src/FlaUI.Core/AutomationElements/ComboBox.cs
+++ b/src/FlaUI.Core/AutomationElements/ComboBox.cs
@@ -248,11 +248,16 @@ namespace FlaUI.Core.AutomationElements
         /// Select the first item which matches the given text.
         /// </summary>
         /// <param name="textToFind">The text to search for.</param>
-        /// <returns>The first found item or null if no item matches.</returns>
+        /// <returns>The first found item.</returns>
+        /// <exception cref="ArgumentException">Thrown if no item matches the specified text.</exception>
         public ComboBoxItem? Select(string textToFind)
         {
             var foundItem = Items.FirstOrDefault(item => item.Text.Equals(textToFind));
-            foundItem?.Select();
+            if (foundItem == null)
+            {
+                throw new ArgumentException($"Item with text '{textToFind}' not found in ComboBox.");
+            }
+            foundItem.Select();
             return foundItem;
         }
 


### PR DESCRIPTION
https://github.com/FlaUI/FlaUI/issues/674

Do not ignore if a non existent text is selected, but raise an exception.
This might be a breaking change, since Null is not returned anymore, but an exception thrown