### PR TITLE
Add horizontal and vertical scroll methods

### DIFF
--- a/src/FlaUI.Core/Extensions/ScrollPatternExtensions.cs
+++ b/src/FlaUI.Core/Extensions/ScrollPatternExtensions.cs
@@ -1,0 +1,51 @@
+﻿using FlaUI.Core.Definitions;
+using FlaUI.Core.Patterns;
+
+namespace FlaUI.Core.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="IScrollPattern"/> objects.
+    /// </summary>
+    public static class ScrollPatternExtensions
+    {
+        /// <summary>
+        /// Scrolls horizontally by the specified amount.
+        /// </summary>
+        /// <param name="pattern">Scroll pattern object to act upon.</param>
+        /// <param name="horizontalAmount">Amount to scroll horizontally.</param>
+        public static void ScrollHorizontally(this IScrollPattern pattern, ScrollAmount horizontalAmount)
+        {
+            pattern.Scroll(horizontalAmount, ScrollAmount.NoAmount);
+        }
+
+        /// <summary>
+        /// Scrolls vertically by the specified amount.
+        /// </summary>
+        /// <param name="pattern">Scroll pattern object to act upon.</param>
+        /// <param name="verticalAmount">Amount to scroll vertically.</param>
+        public static void ScrollVertically(this IScrollPattern pattern, ScrollAmount verticalAmount)
+        {
+            pattern.Scroll(ScrollAmount.NoAmount, verticalAmount);
+        }
+
+        /// <summary>
+        /// Scrolls horizontally by the specified percentage.
+        /// </summary>
+        /// <param name="pattern">Scroll pattern object to act upon.</param>
+        /// <param name="horizontalPercent">Percentage to scroll horizontally.</param>
+        public static void SetHorizontalScrollPercent(this IScrollPattern pattern, double horizontalPercent)
+        {
+            pattern.SetScrollPercent(horizontalPercent, ScrollPatternConstants.NoScroll);
+        }
+
+        /// <summary>
+        /// Scrolls vertically by the specified percentage.
+        /// </summary>
+        /// <param name="pattern">Scroll pattern object to act upon.</param>
+        /// <param name="verticalPercent">Percentage to scroll vertically.</param>
+        public static void SetVerticalScrollPercent(this IScrollPattern pattern, double verticalPercent)
+        {
+            pattern.SetScrollPercent(ScrollPatternConstants.NoScroll, verticalPercent);
+        }
+    }
+}

--- a/src/FlaUI.Core/Patterns/ScrollPattern.cs
+++ b/src/FlaUI.Core/Patterns/ScrollPattern.cs
@@ -22,12 +22,6 @@ namespace FlaUI.Core.Patterns
 
         void Scroll(ScrollAmount horizontalAmount, ScrollAmount verticalAmount);
         void SetScrollPercent(double horizontalPercent, double verticalPercent);
-
-        void ScrollHorizontally(ScrollAmount horizontalAmount);
-        void SetHorizontalScrollPercent(double horizontalPercent);
-
-        void ScrollVertically(ScrollAmount verticalAmount);
-        void SetVerticalScrollPercent(double verticalPercent);
     }
 
     public interface IScrollPatternPropertyIds
@@ -65,25 +59,5 @@ namespace FlaUI.Core.Patterns
 
         public abstract void Scroll(ScrollAmount horizontalAmount, ScrollAmount verticalAmount);
         public abstract void SetScrollPercent(double horizontalPercent, double verticalPercent);
-
-        public void ScrollHorizontally(ScrollAmount horizontalAmount)
-        {
-            Scroll(horizontalAmount, ScrollAmount.NoAmount);
-        }
-
-        public void SetHorizontalScrollPercent(double horizontalPercent)
-        {
-            SetScrollPercent(horizontalPercent, ScrollPatternConstants.NoScroll);
-        }
-
-        public void ScrollVertically(ScrollAmount verticalAmount)
-        {
-            Scroll(ScrollAmount.NoAmount, verticalAmount);
-        }
-
-        public void SetVerticalScrollPercent(double verticalPercent)
-        {
-            SetScrollPercent(ScrollPatternConstants.NoScroll, verticalPercent);
-        }
     }
 }

--- a/src/FlaUI.Core/Patterns/ScrollPattern.cs
+++ b/src/FlaUI.Core/Patterns/ScrollPattern.cs
@@ -22,6 +22,12 @@ namespace FlaUI.Core.Patterns
 
         void Scroll(ScrollAmount horizontalAmount, ScrollAmount verticalAmount);
         void SetScrollPercent(double horizontalPercent, double verticalPercent);
+
+        void ScrollHorizontally(ScrollAmount horizontalAmount);
+        void SetHorizontalScrollPercent(double horizontalPercent);
+
+        void ScrollVertically(ScrollAmount verticalAmount);
+        void SetVerticalScrollPercent(double verticalPercent);
     }
 
     public interface IScrollPatternPropertyIds
@@ -59,5 +65,25 @@ namespace FlaUI.Core.Patterns
 
         public abstract void Scroll(ScrollAmount horizontalAmount, ScrollAmount verticalAmount);
         public abstract void SetScrollPercent(double horizontalPercent, double verticalPercent);
+
+        public void ScrollHorizontally(ScrollAmount horizontalAmount)
+        {
+            Scroll(horizontalAmount, ScrollAmount.NoAmount);
+        }
+
+        public void SetHorizontalScrollPercent(double horizontalPercent)
+        {
+            SetScrollPercent(horizontalPercent, ScrollPatternConstants.NoScroll);
+        }
+
+        public void ScrollVertically(ScrollAmount verticalAmount)
+        {
+            Scroll(ScrollAmount.NoAmount, verticalAmount);
+        }
+
+        public void SetVerticalScrollPercent(double verticalPercent)
+        {
+            SetScrollPercent(ScrollPatternConstants.NoScroll, verticalPercent);
+        }
     }
 }


### PR DESCRIPTION
It's often the case where you need to scroll only horizontally or vertically, rather than both at the same time. In order to make this a bit easier to do, I've added some additional methods for scrolling just one way or the other. This saves the caller from having to always use `ScrollAmount.NoAmount` or `ScrollPatternConstants.NoScroll` for one of the parameters whenever the `Scroll` and `SetScrollPercent` methods are used.