### PR TITLE
Increment copyright year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2024
+Copyright (c) 2016-2025
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/FlaUI.Core/FlaUI.Core.csproj
+++ b/src/FlaUI.Core/FlaUI.Core.csproj
@@ -15,7 +15,7 @@
     <Product>FlaUI</Product>
     <Authors>Roemer</Authors>
     <Description>Library with base elements used in the concrete implementations of FlaUI.</Description>
-    <Copyright>Copyright (c) 2016-2024</Copyright>
+    <Copyright>Copyright (c) 2016-2025</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/FlaUI/FlaUI</PackageProjectUrl>
     <PackageIcon>FlaUI.png</PackageIcon>

--- a/src/FlaUI.TestUtilities/FlaUI.TestUtilities.csproj
+++ b/src/FlaUI.TestUtilities/FlaUI.TestUtilities.csproj
@@ -12,7 +12,7 @@
     <Product>FlaUI.TestUtilities</Product>
     <Authors>Roemer</Authors>
     <Description>Library that provides some helper classes and methods for easier testing with FlaUI.</Description>
-    <Copyright>Copyright (c) 2019-2024</Copyright>
+    <Copyright>Copyright (c) 2019-2025</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/FlaUI/FlaUI</PackageProjectUrl>
     <RepositoryUrl>https://github.com/FlaUI/FlaUI</RepositoryUrl>

--- a/src/FlaUI.UIA2/FlaUI.UIA2.csproj
+++ b/src/FlaUI.UIA2/FlaUI.UIA2.csproj
@@ -15,7 +15,7 @@
     <Product>FlaUI</Product>
     <Authors>Roemer</Authors>
     <Description>Library to use FlaUI with UIA2.</Description>
-    <Copyright>Copyright (c) 2016-2024</Copyright>
+    <Copyright>Copyright (c) 2016-2025</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/FlaUI/FlaUI</PackageProjectUrl>
     <PackageIcon>FlaUI.png</PackageIcon>

--- a/src/FlaUI.UIA3/FlaUI.UIA3.csproj
+++ b/src/FlaUI.UIA3/FlaUI.UIA3.csproj
@@ -14,7 +14,7 @@
     <Product>FlaUI</Product>
     <Authors>Roemer</Authors>
     <Description>Library to use FlaUI with UIA3.</Description>
-    <Copyright>Copyright (c) 2016-2024</Copyright>
+    <Copyright>Copyright (c) 2016-2025</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/FlaUI/FlaUI</PackageProjectUrl>
     <PackageIcon>FlaUI.png</PackageIcon>


### PR DESCRIPTION
Small change to bump up the copyright year from 2024 to 2025.