### PR TITLE
Handle incorrect time offset when system time changes during recording

### DIFF
--- a/src/FlaUI.Core/Capturing/VideoRecorder.cs
+++ b/src/FlaUI.Core/Capturing/VideoRecorder.cs
@@ -285,22 +285,10 @@ namespace FlaUI.Core.Capturing
 
         private class ImageData : IDisposable
         {
-            public int Width
-            {
-                get; set;
-            }
-            public int Height
-            {
-                get; set;
-            }
-            public bool IsRepeatFrame
-            {
-                get; private set;
-            }
-            public byte[]? Data
-            {
-                get; set;
-            }
+            public int Width { get; set; }
+            public int Height { get; set; }
+            public bool IsRepeatFrame { get; private set; }
+            public byte[]? Data { get; set; }
 
             public static readonly ImageData RepeatImage = new ImageData { IsRepeatFrame = true };
 

--- a/src/FlaUI.Core/Capturing/VideoRecorder.cs
+++ b/src/FlaUI.Core/Capturing/VideoRecorder.cs
@@ -93,7 +93,15 @@ namespace FlaUI.Core.Capturing
                 var timeTillNextFrame = timestamp + frameInterval - DateTime.UtcNow;
                 if (timeTillNextFrame > TimeSpan.Zero)
                 {
-                    await Task.Delay(timeTillNextFrame);
+                    if (timeTillNextFrame > TimeSpan.FromSeconds(1))
+                    {
+                        // Happens when the system date is set to an earlier time during recording
+                        await Task.Delay(frameInterval);
+                    }
+                    else
+                    {
+                        await Task.Delay(timeTillNextFrame);
+                    }
                 }
             }
             if (totalMissedFrames > 0 && _settings.LogMissingFrames)
@@ -277,10 +285,22 @@ namespace FlaUI.Core.Capturing
 
         private class ImageData : IDisposable
         {
-            public int Width { get; set; }
-            public int Height { get; set; }
-            public bool IsRepeatFrame { get; private set; }
-            public byte[]? Data { get; set; }
+            public int Width
+            {
+                get; set;
+            }
+            public int Height
+            {
+                get; set;
+            }
+            public bool IsRepeatFrame
+            {
+                get; private set;
+            }
+            public byte[]? Data
+            {
+                get; set;
+            }
 
             public static readonly ImageData RepeatImage = new ImageData { IsRepeatFrame = true };
 


### PR DESCRIPTION
**Describe the bug**
During an automation test, we modify the system date to a later date, do some tests, than change it back to the original.
After the second modification, where the system date was changed to an earlier time (with 1 hour), the recording seemingly stopped, but in reality, it was delayed for 1 hour.

**Reproducibility**
Start a recording and set the system date back by 1 hour.
The next time when the recording task will calculate the necessary delay before the next capture, the calculated delay will be approximately 1 hour.
Since the safety check only begates negative timestamps, the Task.Delay will be performed and the recording will be stopped (delayed).

**Code snippets**
_FlaUI.Core.Capturing.VideoRecorder.RecordLoop()_

    var timestamp = DateTime.UtcNow;

    ... actual recording logic
    ... at this point, the system time is modified

    var timeTillNextFrame = timestamp + frameInterval - DateTime.UtcNow;
    if (timeTillNextFrame > TimeSpan.Zero)
    {
        await Task.Delay(timeTillNextFrame);
    }

**The fixed version**

    if (timeTillNextFrame > TimeSpan.Zero)
    {
        if (timeTillNextFrame > TimeSpan.FromSeconds(1))
        {
            // Happens when the system date is set to an earlier time during recording
            await Task.Delay(frameInterval);
        }
        else
        {
            await Task.Delay(timeTillNextFrame);
        }
    }

The `timeTillNextFrame` value should never be greater than 1 second, since the minimum frame rate is 1 (or at least, it should be).
This way, the issue is resolved.