### PR TITLE
Add minimise and maximise button ID alternatives

### DIFF
--- a/src/FlaUI.Core/AutomationElements/TitleBar.cs
+++ b/src/FlaUI.Core/AutomationElements/TitleBar.cs
@@ -17,12 +17,12 @@ namespace FlaUI.Core.AutomationElements
         /// <summary>
         /// Gets the minimize button element.
         /// </summary>
-        public Button? MinimizeButton => FindButton("Minimize");
+        public Button? MinimizeButton => FindButton("Minimize") ?? FindButton("Minimise");
 
         /// <summary>
         /// Gets the maximize button element.
         /// </summary>
-        public Button? MaximizeButton => FindButton("Maximize");
+        public Button? MaximizeButton => FindButton("Maximize") ?? FindButton("Maximise");
 
         /// <summary>
         /// Gets the restore button element.


### PR DESCRIPTION
Depending on your Windows system settings, the automation ID for the title bar "Maximize" and "Minimize" buttons can potentially be "Maximise" and "Minimise", respectively. In order to ensure that these buttons can still be found, these changes add these IDs as alternative backups.