### PR TITLE
Fix XPath exceptions when using XPath functions on attributes that may not exist on elements

### DIFF
--- a/src/FlaUI.Core.UITests/XPathTests.cs
+++ b/src/FlaUI.Core.UITests/XPathTests.cs
@@ -54,6 +54,22 @@ namespace FlaUI.Core.UITests
         }
 
         [Test]
+        public void NotepadFindAllWithFunction()
+        {
+            using (var automation = UtilityMethods.GetAutomation(AutomationType.UIA3))
+            {
+                var app = Application.Launch("notepad.exe");
+                var window = app.GetMainWindow(automation);
+                // Look for "Line Up" and "Line Down"
+                var elem = window.FindAllByXPath("//*[contains(@Name, 'Line')]");
+                Assert.That(elem.Length, Is.EqualTo(2));
+                Assert.That(elem[0].ControlType, Is.EqualTo(ControlType.Button));
+                Assert.That(elem[1].ControlType, Is.EqualTo(ControlType.Button));
+                app.Close();
+            }
+        }
+
+        [Test]
         public void NotePadFindAllIndexed()
         {
             using (var automation = UtilityMethods.GetAutomation(AutomationType.UIA3))

--- a/src/FlaUI.Core.UITests/XPathTests.cs
+++ b/src/FlaUI.Core.UITests/XPathTests.cs
@@ -54,22 +54,6 @@ namespace FlaUI.Core.UITests
         }
 
         [Test]
-        public void NotepadFindAllWithFunction()
-        {
-            using (var automation = UtilityMethods.GetAutomation(AutomationType.UIA3))
-            {
-                var app = Application.Launch("notepad.exe");
-                var window = app.GetMainWindow(automation);
-                // Look for "Line Up" and "Line Down"
-                var elem = window.FindAllByXPath("//*[contains(@Name, 'Line')]");
-                Assert.That(elem.Length, Is.EqualTo(2));
-                Assert.That(elem[0].ControlType, Is.EqualTo(ControlType.Button));
-                Assert.That(elem[1].ControlType, Is.EqualTo(ControlType.Button));
-                app.Close();
-            }
-        }
-
-        [Test]
         public void NotePadFindAllIndexed()
         {
             using (var automation = UtilityMethods.GetAutomation(AutomationType.UIA3))
@@ -95,7 +79,9 @@ namespace FlaUI.Core.UITests
             {
                 var app = Application.Launch("mspaint.exe");
                 var window = app.GetMainWindow(automation);
-                var button = window.FindFirstByXPath($"//Button[@Name='{GetPaintBrushName()}']");
+
+                var elementType = OperatingSystem.IsWindows11() ? "RadioButton":"Button";
+                var button = window.FindFirstByXPath($"//{elementType}[@Name='{GetPaintBrushName()}']");
 
                 Assert.That(button, Is.Not.Null);
                 app.Close();
@@ -111,6 +97,23 @@ namespace FlaUI.Core.UITests
                 var window = app.GetMainWindow(automation);
                 var unknown = window.FindFirstByXPath("//Custom");
                 Assert.That(unknown, Is.Not.Null);
+                app.Close();
+            }
+        }
+
+
+        [Test]
+        public void NotepadFindAllWithXPathFunction()
+        {
+            using (var automation = UtilityMethods.GetAutomation(AutomationType.UIA3))
+            {
+                var app = Application.Launch("notepad.exe");
+                var window = app.GetMainWindow(automation);
+                // Look for "Line Up" and "Line Down"
+                var elem = window.FindAllByXPath("//*[contains(@Name, 'Line')]");
+                Assert.That(elem.Length, Is.EqualTo(2));
+                Assert.That(elem[0].ControlType, Is.EqualTo(ControlType.Button));
+                Assert.That(elem[1].ControlType, Is.EqualTo(ControlType.Button));
                 app.Close();
             }
         }

--- a/src/FlaUI.Core/AutomationElementXPathNavigator.cs
+++ b/src/FlaUI.Core/AutomationElementXPathNavigator.cs
@@ -273,23 +273,23 @@ namespace FlaUI.Core
             switch ((ElementAttributes)attributeIndex)
             {
                 case ElementAttributes.AutomationId:
-                    return _currentElement.Properties.AutomationId.ValueOrDefault ?? "";
+                    return _currentElement.Properties.AutomationId.ValueOrDefault ?? String.Empty;
                 case ElementAttributes.Name:
-                    return _currentElement.Properties.Name.ValueOrDefault ?? "";
+                    return _currentElement.Properties.Name.ValueOrDefault ?? String.Empty;
                 case ElementAttributes.ClassName:
-                    return _currentElement.Properties.ClassName.ValueOrDefault ?? "";
+                    return _currentElement.Properties.ClassName.ValueOrDefault ?? String.Empty;
                 case ElementAttributes.HelpText:
-                    return _currentElement.Properties.HelpText.ValueOrDefault ?? "";
+                    return _currentElement.Properties.HelpText.ValueOrDefault ?? String.Empty;
                 case ElementAttributes.IsPassword:
                     return _currentElement.Properties.IsPassword.ValueOrDefault.ToString().ToLower();
                 case ElementAttributes.FullDescription:
-                    return _currentElement.Properties.FullDescription.ValueOrDefault ?? "";
+                    return _currentElement.Properties.FullDescription.ValueOrDefault ?? String.Empty;
                 case ElementAttributes.ItemType:
-                    return _currentElement.Properties.ItemType.ValueOrDefault ?? "";
+                    return _currentElement.Properties.ItemType.ValueOrDefault ?? String.Empty;
                 case ElementAttributes.AcceleratorKey:
-                    return _currentElement.Properties.AcceleratorKey.ValueOrDefault ?? "";
+                    return _currentElement.Properties.AcceleratorKey.ValueOrDefault ?? String.Empty;
                 case ElementAttributes.AccessKey:
-                    return _currentElement.Properties.AccessKey.ValueOrDefault ?? "";
+                    return _currentElement.Properties.AccessKey.ValueOrDefault ?? String.Empty;
                 case ElementAttributes.IsEnabled:
                     return _currentElement.Properties.IsEnabled.ValueOrDefault.ToString().ToLower();
                 case ElementAttributes.IsOffscreen:

--- a/src/FlaUI.Core/AutomationElementXPathNavigator.cs
+++ b/src/FlaUI.Core/AutomationElementXPathNavigator.cs
@@ -273,23 +273,23 @@ namespace FlaUI.Core
             switch ((ElementAttributes)attributeIndex)
             {
                 case ElementAttributes.AutomationId:
-                    return _currentElement.Properties.AutomationId.ValueOrDefault;
+                    return _currentElement.Properties.AutomationId.ValueOrDefault ?? "";
                 case ElementAttributes.Name:
-                    return _currentElement.Properties.Name.ValueOrDefault;
+                    return _currentElement.Properties.Name.ValueOrDefault ?? "";
                 case ElementAttributes.ClassName:
-                    return _currentElement.Properties.ClassName.ValueOrDefault;
+                    return _currentElement.Properties.ClassName.ValueOrDefault ?? "";
                 case ElementAttributes.HelpText:
-                    return _currentElement.Properties.HelpText.ValueOrDefault;
+                    return _currentElement.Properties.HelpText.ValueOrDefault ?? "";
                 case ElementAttributes.IsPassword:
                     return _currentElement.Properties.IsPassword.ValueOrDefault.ToString().ToLower();
                 case ElementAttributes.FullDescription:
-                    return _currentElement.Properties.FullDescription.ValueOrDefault;
+                    return _currentElement.Properties.FullDescription.ValueOrDefault ?? "";
                 case ElementAttributes.ItemType:
-                    return _currentElement.Properties.ItemType.ValueOrDefault;
+                    return _currentElement.Properties.ItemType.ValueOrDefault ?? "";
                 case ElementAttributes.AcceleratorKey:
-                    return _currentElement.Properties.AcceleratorKey.ValueOrDefault;
+                    return _currentElement.Properties.AcceleratorKey.ValueOrDefault ?? "";
                 case ElementAttributes.AccessKey:
-                    return _currentElement.Properties.AccessKey.ValueOrDefault;
+                    return _currentElement.Properties.AccessKey.ValueOrDefault ?? "";
                 case ElementAttributes.IsEnabled:
                     return _currentElement.Properties.IsEnabled.ValueOrDefault.ToString().ToLower();
                 case ElementAttributes.IsOffscreen:


### PR DESCRIPTION
Problem:
If the element tree has elements that don't have specific attributes (e.g. "Name"), when you use an XPath query containing a function, such as "contains" that attempts to access that attribute, FlaUI will exception.

Resolution:
XPathNavigator expects non-null values.  Modified code to return empty strings, rather than null values.
Added unit test to cover scenario.