### PR TITLE
Prevent disposing external Process in Application

### DIFF
--- a/src/FlaUI.Core.UnitTests/ApplicationTests.cs
+++ b/src/FlaUI.Core.UnitTests/ApplicationTests.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Diagnostics;
+using FlaUI.Core;
+using NUnit.Framework;
+
+namespace FlaUI.Core.UnitTests
+{
+    [TestFixture]
+    public class ApplicationTests
+    {
+        [Test]
+        public void DisposeDoesNotDisposeProcessProvidedToConstructor()
+        {
+            using (var process = Process.GetCurrentProcess())
+            {
+                using (new Application(process))
+                {
+                }
+
+                AssertProcessCanStillBeUsed(process);
+            }
+        }
+
+        [Test]
+        public void DisposeDoesNotDisposeProcessProvidedToAttach()
+        {
+            using (var process = Process.GetCurrentProcess())
+            {
+                using (Application.Attach(process))
+                {
+                }
+
+                AssertProcessCanStillBeUsed(process);
+            }
+        }
+
+        [Test]
+        public void WaitWhileMainHandleIsMissingDoesNotDisposeProcessProvidedToAttach()
+        {
+            using (var process = Process.GetCurrentProcess())
+            {
+                using (var app = Application.Attach(process))
+                {
+                    app.WaitWhileMainHandleIsMissing(TimeSpan.Zero);
+                }
+
+                AssertProcessCanStillBeUsed(process);
+            }
+        }
+
+        [Test]
+        public void WaitWhileMainHandleIsMissingCanRefreshMultipleTimesWithoutDisposingOriginalProcess()
+        {
+            using (var process = StartLongRunningProcess())
+            {
+                var processId = process.Id;
+                try
+                {
+                    using (var app = Application.Attach(process))
+                    {
+                        app.WaitWhileMainHandleIsMissing(TimeSpan.FromMilliseconds(150));
+                    }
+
+                    AssertProcessCanStillBeUsed(process);
+                }
+                finally
+                {
+                    KillProcess(process, processId);
+                }
+            }
+        }
+
+        [Test]
+        public void DisposeAfterWaitWhileMainHandleIsMissingDoesNotDisposeOriginalProcess()
+        {
+            using (var process = StartLongRunningProcess())
+            {
+                var processId = process.Id;
+                try
+                {
+                    var app = Application.Attach(process);
+                    app.WaitWhileMainHandleIsMissing(TimeSpan.Zero);
+                    app.Dispose();
+
+                    AssertProcessCanStillBeUsed(process);
+                }
+                finally
+                {
+                    KillProcess(process, processId);
+                }
+            }
+        }
+
+        [Test]
+        public void AttachByProcessIdDoesNotAffectExistingProcessInstance()
+        {
+            using (var process = StartLongRunningProcess())
+            {
+                var processId = process.Id;
+                try
+                {
+                    using (var app = Application.Attach(process.Id))
+                    {
+                        app.WaitWhileMainHandleIsMissing(TimeSpan.Zero);
+                    }
+
+                    AssertProcessCanStillBeUsed(process);
+                }
+                finally
+                {
+                    KillProcess(process, processId);
+                }
+            }
+        }
+
+        [Test]
+        public void KillStillTerminatesTargetProcessWhenProcessObjectIsExternal()
+        {
+            using (var process = StartLongRunningProcess())
+            {
+                var processId = process.Id;
+                try
+                {
+                    using (var app = Application.Attach(process))
+                    {
+                        app.Kill();
+                    }
+
+                    Assert.That(process.HasExited, Is.True);
+                    Assert.That(process.ExitCode, Is.Not.EqualTo(Int32.MinValue));
+                }
+                finally
+                {
+                    KillProcess(process, processId);
+                }
+            }
+        }
+
+        private static void AssertProcessCanStillBeUsed(Process process)
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                Assert.That(process.Id, Is.GreaterThan(0));
+                Assert.That(process.HasExited, Is.False);
+            });
+        }
+
+        private static Process StartLongRunningProcess()
+        {
+            var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe",
+                Arguments = "/c ping 127.0.0.1 -n 6 > nul",
+                CreateNoWindow = true,
+                UseShellExecute = false
+            });
+
+            if (process == null)
+            {
+                throw new InvalidOperationException("Failed to start test process.");
+            }
+
+            return process;
+        }
+
+        private static void KillProcess(Process process, int processId)
+        {
+            try
+            {
+                if (process.HasExited)
+                {
+                    return;
+                }
+
+                process.Kill();
+                process.WaitForExit();
+            }
+            catch (InvalidOperationException)
+            {
+                KillProcessById(processId);
+            }
+        }
+
+        private static void KillProcessById(int processId)
+        {
+            try
+            {
+                using (var process = Process.GetProcessById(processId))
+                {
+                    if (process.HasExited)
+                    {
+                        return;
+                    }
+
+                    process.Kill();
+                    process.WaitForExit();
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+    }
+}

--- a/src/FlaUI.Core.UnitTests/FlaUI.Core.UnitTests.csproj
+++ b/src/FlaUI.Core.UnitTests/FlaUI.Core.UnitTests.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApplicationTests.cs" />
     <Compile Include="Logging\LoggerBaseTests.cs" />
     <Compile Include="Logging\TestLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/FlaUI.Core/Application.cs
+++ b/src/FlaUI.Core/Application.cs
@@ -22,6 +22,11 @@ namespace FlaUI.Core
         private Process _process;
 
         /// <summary>
+        /// Flag to indicate if FlaUI created the current process instance and should dispose it.
+        /// </summary>
+        private bool _disposeProcess;
+
+        /// <summary>
         /// Flag to indicate if Dispose has already been called.
         /// </summary>
         private bool _disposed;
@@ -68,7 +73,7 @@ namespace FlaUI.Core
         /// <param name="processId">The process id.</param>
         /// <param name="isStoreApp">Flag to define if it's a store app or not.</param>
         public Application(int processId, bool isStoreApp = false)
-            : this(FindProcess(processId), isStoreApp)
+            : this(FindProcess(processId), isStoreApp, true)
         {
         }
 
@@ -78,8 +83,14 @@ namespace FlaUI.Core
         /// <param name="process">The process.</param>
         /// <param name="isStoreApp">Flag to define if it's a store app or not.</param>
         public Application(Process process, bool isStoreApp = false)
+            : this(process, isStoreApp, false)
+        {
+        }
+
+        private Application(Process process, bool isStoreApp, bool disposeProcess)
         {
             _process = process ?? throw new ArgumentNullException(nameof(process));
+            _disposeProcess = disposeProcess;
             IsStoreApp = isStoreApp;
         }
 
@@ -156,7 +167,7 @@ namespace FlaUI.Core
             }
             if (disposing)
             {
-                _process?.Dispose();
+                DisposeProcess();
             }
             _disposed = true;
         }
@@ -168,7 +179,7 @@ namespace FlaUI.Core
         /// <returns>An application instance which is attached to the process.</returns>
         public static Application Attach(int processId)
         {
-            return Attach(FindProcess(processId));
+            return Attach(FindProcess(processId), true);
         }
 
         /// <summary>
@@ -178,8 +189,13 @@ namespace FlaUI.Core
         /// <returns>An application instance which is attached to the process.</returns>
         public static Application Attach(Process process)
         {
+            return Attach(process, false);
+        }
+
+        private static Application Attach(Process process, bool disposeProcess)
+        {
             Logger.Default.Debug($"[Attaching to process:{process.Id}] [Process name:{process.ProcessName}] [Process full path:{WindowsApiTools.GetMainModuleFilepath(process)}]");
-            return new Application(process);
+            return new Application(process, false, disposeProcess);
         }
 
         /// <summary>
@@ -193,7 +209,7 @@ namespace FlaUI.Core
             var processes = FindProcess(executable);
             if (processes.Length > index)
             {
-                return Attach(processes[index]);
+                return Attach(processes[index], true);
             }
             throw new Exception("Unable to find process with name: " + executable);
         }
@@ -204,7 +220,7 @@ namespace FlaUI.Core
         public static Application AttachOrLaunch(ProcessStartInfo processStartInfo)
         {
             var processes = FindProcess(processStartInfo.FileName);
-            return processes.Length == 0 ? Launch(processStartInfo) : Attach(processes[0]);
+            return processes.Length == 0 ? Launch(processStartInfo) : Attach(processes[0], true);
         }
 
         /// <summary>
@@ -252,7 +268,7 @@ namespace FlaUI.Core
                 throw;
             }
 
-            return new Application(process);
+            return new Application(process, false, true);
         }
 
         /// <summary>
@@ -263,7 +279,7 @@ namespace FlaUI.Core
         public static Application LaunchStoreApp(string appUserModelId, string arguments = "")
         {
             var process = WindowsStoreAppLauncher.Launch(appUserModelId, arguments);
-            return new Application(process, true);
+            return new Application(process, true, true);
         }
 
         /// <summary>
@@ -287,9 +303,7 @@ namespace FlaUI.Core
             var waitTime = waitTimeout ?? TimeSpan.FromMilliseconds(-1);
             return Retry.WhileTrue(() =>
             {
-                int processId = _process.Id;
-                _process.Dispose();
-                _process = FindProcess(processId);
+                RefreshProcess();
                 return _process.MainWindowHandle == IntPtr.Zero;
             }, waitTime, TimeSpan.FromMilliseconds(50)).Result;
         }
@@ -342,6 +356,22 @@ namespace FlaUI.Core
         private static Process[] FindProcess(string executable)
         {
             return Process.GetProcessesByName(Path.GetFileNameWithoutExtension(executable));
+        }
+
+        private void RefreshProcess()
+        {
+            var processId = _process.Id;
+            DisposeProcess();
+            _process = FindProcess(processId);
+            _disposeProcess = true;
+        }
+
+        private void DisposeProcess()
+        {
+            if (_disposeProcess)
+            {
+                _process?.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #534
Fixes #727

Updates `Application` process ownership so externally supplied `Process` instances are not disposed by FlaUI during attach, main-window refresh, or disposal.